### PR TITLE
US-B2B-01: Implement product creation endpoint

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,6 +1,12 @@
 # Summary
 
-Implemented `POST /api/v1/products` for B2B product creation. The endpoint creates products with `status=CREATED`, persists `seller_id` from the Bearer JWT `seller_id` claim only, ignores any body `seller_id`, returns `skus=[]`, and keeps SKU-less products out of moderation.
+## US-B2B-01 Product Creation
+
+Migrated `POST /api/v1/products` to the authoritative `flow/neomarket-b2b.yaml` contract. The endpoint creates products with `status=CREATED`, persists `seller_id` from the Bearer JWT `seller_id` claim only, ignores any body `seller_id` or `sellerId`, returns `skus=[]`, and keeps SKU-less products out of moderation.
+
+Images are optional on create; omitted images and `images=[]` both create the product and return `images=[]`. `category_id` remains required, and nonexistent categories return endpoint-scoped `422` field details for `category_id`.
+
+Database IDs remain integers internally. The create response serializes product `id` and `category_id` as strings at the response boundary for contract compatibility, and adds response-boundary compatibility fields: `slug`, `deleted`, `blocking_reason_id`, and `moderator_comment`.
 
 # Validation
 
@@ -12,7 +18,7 @@ python -m pytest tests/api/test_products.py -q
 
 # Contract Notes
 
-`flow/b2b-flows.md` and `flow/b2b.yaml` were used as local reference inputs and are not committed. The canonical flow requires `POST /api/v1/products`, while the local OpenAPI reference currently lists `POST /api/products`; the implementation follows `/api/v1/products` because that is the assignment endpoint and the existing FastAPI router prefix.
+`flow/neomarket-b2b.yaml` is the authoritative contract for US-B2B-01 product creation.
 
 # ADR: Product Characteristics Storage
 

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -10,7 +10,7 @@ Database IDs remain integers internally. The create response serializes product 
 
 Review fixes:
 - Images are required by canon-flow B2B-1.
-- Nested product images and characteristics now include `id` per OpenAPI response schemas.
+- Shared `ImageOut` and `CharacteristicOut` now include server `id` per OpenAPI response schemas.
 
 # Validation
 

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,29 +1,36 @@
 # Summary
 
-## US-B2B-01 Product Creation
+## US-B2B-01: создание продукта
 
-Implemented `POST /api/v1/products` for B2B product creation. The endpoint creates products with `status=CREATED`, persists `seller_id` from the Bearer JWT `seller_id` claim only, ignores any body `seller_id` or `sellerId`, returns `skus=[]`, and keeps SKU-less products out of moderation.
+Реализован `POST /api/v1/products` для B2B-создания продукта. Эндпоинт создает продукт со статусом `CREATED`, сохраняет `seller_id` только из claim `seller_id` в Bearer JWT, игнорирует любые `seller_id` или `sellerId` из тела запроса, возвращает `skus=[]` и не отправляет продукт без SKU на модерацию.
 
-Images are required by canon-flow B2B-1. Omitted images and `images=[]` return canonical `400 INVALID_REQUEST` with `At least one image is required`. `category_id` remains required, and nonexistent categories return endpoint-scoped `422` field details for `category_id`.
+`images` обязательны по canon-flow B2B-1. Отсутствующее поле `images` и `images=[]` возвращают канонический `400 INVALID_REQUEST` с полевым описанием `At least one image is required`.
 
-Database IDs remain integers internally. The create response serializes product `id`, `category_id`, nested product image IDs, and nested product characteristic IDs as strings at the response boundary for contract compatibility. The create response also includes response-boundary compatibility fields: `slug`, `deleted`, `blocking_reason_id`, and `moderator_comment`.
+Контрактные идентификаторы продуктов теперь сохраняются как реальные UUID-backed значения, без stringification integer ID на границе ответа. Это покрывает `Category.id`, `Product.id`, `Product.category_id`, `Product.seller_id`, `ProductImage.id/product_id`, `ProductCharacteristic.id/product_id`, `SKU.id/product_id`, `SKUCharacteristic.id/sku_id` и ссылки invoice item на SKU. `ImageOut`, `CharacteristicOut` и вложенные SKU ids отдают UUID напрямую.
 
-Review fixes:
-- Images are required by canon-flow B2B-1.
-- Shared `ImageOut` and `CharacteristicOut` now include server `id` per OpenAPI response schemas.
+`ProductRead` и `ProductCreateRead` включают обязательные поля совместимости ответа: `slug`, `deleted`, `blocking_reason_id` и `moderator_comment`. Вложенные ответы SKU включают seller-view поля SKU, требуемые unified contract. Если экземпляр SKU-модели содержит одиночный URL `image` без отдельной таблицы изображений SKU, ответ формирует детерминированный UUID image id через `uuid5("sku-image:{sku_id}:0")`.
+
+Валидация запроса теперь возвращает плоскую Error schema: `422 {"code":"VALIDATION_ERROR","message":"..."}`. Отсутствующий `category_id`, невалидный UUID-синтаксис `category_id`, валидный, но несуществующий `category_id`, а также невалидные `title`/`description` используют эту форму вместо стандартного FastAPI `detail` list. Пользовательские ошибки `400`, `401`, `404` и `409` используют единый формат `{code, message}`.
+
+UUID-миграция рассчитана на свежее/текущее состояние проекта. Она переводит seeded categories на UUID и конвертирует контрактные product columns в UUID, но не пытается сделать полный data-preserving remap для уже заполненных PostgreSQL связей product/SKU/image/characteristic.
 
 # Validation
 
-Pytest proof command:
+Pytest proof commands:
 
 ```powershell
-python -m pytest tests/api/test_products.py -q -k "test_create_product_returns_201_with_created_status or test_seller_id_taken_from_jwt or test_missing_images_returns_400 or test_missing_category_returns_422_with_field_details or test_invalid_category_id_returns_422_with_field_details"
+python -m pytest tests/api/test_products.py -vv
+python -m pytest tests/api/test_products.py tests/api/test_skus.py -vv
 ```
+
+В рамках обновления этого описания тесты и форматтеры не запускались; проверялся только diff `PR_DESCRIPTION.md`.
 
 # Contract Notes
 
-`flow/neomarket-b2b.yaml` is the authoritative contract for US-B2B-01 product creation.
+Контракт сверялся с merged B2B OpenAPI и `b2b/openapi.yaml`. Локальное зеркало финальной OpenAPI-спецификации в этом репозитории находится в `flow/openapi.yaml`.
 
-# ADR: Product Characteristics Storage
+`flow/neomarket-b2b.yaml` не рассматривается как актуальный authoritative source для US-B2B-01.
 
-For product characteristics, this service keeps the existing separate `product_characteristics` table instead of moving values into a JSON field on `products` or introducing a generic EAV schema. A JSON field is easy to extend, but filtering by characteristic values becomes database-specific and harder to index predictably. A generic EAV schema is flexible, but it makes common filtering joins more complex and weakens type clarity. The separate `ProductCharacteristic` table is the smallest fit for the current model: adding new characteristics only inserts more rows, while filtering remains a straightforward join.
+# ADR: хранение характеристик продукта
+
+Для характеристик продукта сервис сохраняет существующую отдельную таблицу `product_characteristics`, а не переносит значения в JSON-поле на `products` и не вводит универсальную EAV-схему. JSON-поле проще расширять, но фильтрация по значениям характеристик становится database-specific и сложнее индексируется предсказуемо. EAV-схема гибкая, но усложняет типовые filtering joins и ослабляет ясность типов. Отдельная таблица `ProductCharacteristic` остается минимально подходящим решением для текущей модели: добавление новых характеристик требует только вставки новых строк, а фильтрация остается прямым join.

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -2,18 +2,22 @@
 
 ## US-B2B-01 Product Creation
 
-Migrated `POST /api/v1/products` to the authoritative `flow/neomarket-b2b.yaml` contract. The endpoint creates products with `status=CREATED`, persists `seller_id` from the Bearer JWT `seller_id` claim only, ignores any body `seller_id` or `sellerId`, returns `skus=[]`, and keeps SKU-less products out of moderation.
+Implemented `POST /api/v1/products` for B2B product creation. The endpoint creates products with `status=CREATED`, persists `seller_id` from the Bearer JWT `seller_id` claim only, ignores any body `seller_id` or `sellerId`, returns `skus=[]`, and keeps SKU-less products out of moderation.
 
-Images are optional on create; omitted images and `images=[]` both create the product and return `images=[]`. `category_id` remains required, and nonexistent categories return endpoint-scoped `422` field details for `category_id`.
+Images are required by canon-flow B2B-1. Omitted images and `images=[]` return canonical `400 INVALID_REQUEST` with `At least one image is required`. `category_id` remains required, and nonexistent categories return endpoint-scoped `422` field details for `category_id`.
 
-Database IDs remain integers internally. The create response serializes product `id` and `category_id` as strings at the response boundary for contract compatibility, and adds response-boundary compatibility fields: `slug`, `deleted`, `blocking_reason_id`, and `moderator_comment`.
+Database IDs remain integers internally. The create response serializes product `id`, `category_id`, nested product image IDs, and nested product characteristic IDs as strings at the response boundary for contract compatibility. The create response also includes response-boundary compatibility fields: `slug`, `deleted`, `blocking_reason_id`, and `moderator_comment`.
+
+Review fixes:
+- Images are required by canon-flow B2B-1.
+- Nested product images and characteristics now include `id` per OpenAPI response schemas.
 
 # Validation
 
 Pytest proof command:
 
 ```powershell
-python -m pytest tests/api/test_products.py -q
+python -m pytest tests/api/test_products.py -q -k "test_create_product_returns_201_with_created_status or test_seller_id_taken_from_jwt or test_missing_images_returns_400 or test_missing_category_returns_422_with_field_details or test_invalid_category_id_returns_422_with_field_details"
 ```
 
 # Contract Notes

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,19 @@
+# Summary
+
+Implemented `POST /api/v1/products` for B2B product creation. The endpoint creates products with `status=CREATED`, persists `seller_id` from the Bearer JWT `seller_id` claim only, ignores any body `seller_id`, returns `skus=[]`, and keeps SKU-less products out of moderation.
+
+# Validation
+
+Pytest proof command:
+
+```powershell
+python -m pytest tests/api/test_products.py -q
+```
+
+# Contract Notes
+
+`flow/b2b-flows.md` and `flow/b2b.yaml` were used as local reference inputs and are not committed. The canonical flow requires `POST /api/v1/products`, while the local OpenAPI reference currently lists `POST /api/products`; the implementation follows `/api/v1/products` because that is the assignment endpoint and the existing FastAPI router prefix.
+
+# ADR: Product Characteristics Storage
+
+For product characteristics, this service keeps the existing separate `product_characteristics` table instead of moving values into a JSON field on `products` or introducing a generic EAV schema. A JSON field is easy to extend, but filtering by characteristic values becomes database-specific and harder to index predictably. A generic EAV schema is flexible, but it makes common filtering joins more complex and weakens type clarity. The separate `ProductCharacteristic` table is the smallest fit for the current model: adding new characteristics only inserts more rows, while filtering remains a straightforward join.

--- a/migrations/versions/0002_add_product_created_and_seller_id.py
+++ b/migrations/versions/0002_add_product_created_and_seller_id.py
@@ -1,0 +1,33 @@
+"""Add CREATED product status and product seller ownership."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0002_add_product_created_and_seller_id"
+down_revision = "0001_initial_schema"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("ALTER TYPE product_status ADD VALUE IF NOT EXISTS 'CREATED'")
+    op.add_column(
+        "products",
+        sa.Column(
+            "seller_id",
+            sa.String(length=36),
+            nullable=False,
+            server_default="00000000-0000-0000-0000-000000000000",
+        ),
+    )
+    op.alter_column("products", "seller_id", server_default=None)
+    op.alter_column("products", "status", server_default=sa.text("'CREATED'"))
+
+
+def downgrade() -> None:
+    op.alter_column("products", "status", server_default=sa.text("'DRAFT'"))
+    op.drop_column("products", "seller_id")

--- a/migrations/versions/b2b01_uuid_contract_ids.py
+++ b/migrations/versions/b2b01_uuid_contract_ids.py
@@ -1,0 +1,333 @@
+"""Use UUIDs for B2B product contract identifiers."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "b2b01_uuid_contract_ids"
+down_revision = "0002_add_product_created_and_seller_id"
+branch_labels = None
+depends_on = None
+
+
+uuid_type = postgresql.UUID(as_uuid=True)
+
+
+def _drop_fk_if_exists(table_name: str, *constraint_names: str) -> None:
+    for constraint_name in constraint_names:
+        op.execute(f'ALTER TABLE "{table_name}" DROP CONSTRAINT IF EXISTS "{constraint_name}"')
+
+
+def upgrade() -> None:
+    op.execute("CREATE EXTENSION IF NOT EXISTS pgcrypto")
+
+    _drop_fk_if_exists("product_images", "fk_product_images_product_id_products", "product_images_product_id_fkey")
+    _drop_fk_if_exists(
+        "product_characteristics",
+        "fk_product_characteristics_product_id_products",
+        "product_characteristics_product_id_fkey",
+    )
+    _drop_fk_if_exists("skus", "fk_skus_product_id_products", "skus_product_id_fkey")
+    _drop_fk_if_exists(
+        "sku_characteristics",
+        "fk_sku_characteristics_sku_id_skus",
+        "sku_characteristics_sku_id_fkey",
+    )
+    _drop_fk_if_exists("invoice_items", "fk_invoice_items_sku_id_skus", "invoice_items_sku_id_fkey")
+    _drop_fk_if_exists("products", "fk_products_category_id_categories", "products_category_id_fkey")
+
+    op.alter_column("categories", "id", existing_type=sa.Integer(), type_=uuid_type, postgresql_using="gen_random_uuid()")
+    op.alter_column("products", "id", existing_type=sa.Integer(), type_=uuid_type, postgresql_using="gen_random_uuid()")
+    op.alter_column(
+        "products",
+        "category_id",
+        existing_type=sa.Integer(),
+        type_=uuid_type,
+        postgresql_using="gen_random_uuid()",
+    )
+    op.alter_column(
+        "products",
+        "seller_id",
+        existing_type=sa.String(length=36),
+        type_=uuid_type,
+        postgresql_using="seller_id::uuid",
+    )
+    op.alter_column(
+        "product_images",
+        "id",
+        existing_type=sa.Integer(),
+        type_=uuid_type,
+        postgresql_using="gen_random_uuid()",
+    )
+    op.alter_column(
+        "product_images",
+        "product_id",
+        existing_type=sa.Integer(),
+        type_=uuid_type,
+        postgresql_using="gen_random_uuid()",
+    )
+    op.alter_column(
+        "product_characteristics",
+        "id",
+        existing_type=sa.Integer(),
+        type_=uuid_type,
+        postgresql_using="gen_random_uuid()",
+    )
+    op.alter_column(
+        "product_characteristics",
+        "product_id",
+        existing_type=sa.Integer(),
+        type_=uuid_type,
+        postgresql_using="gen_random_uuid()",
+    )
+    op.alter_column(
+        "skus",
+        "id",
+        existing_type=sa.Integer(),
+        type_=uuid_type,
+        postgresql_using="gen_random_uuid()",
+    )
+    op.alter_column(
+        "skus",
+        "product_id",
+        existing_type=sa.Integer(),
+        type_=uuid_type,
+        postgresql_using="gen_random_uuid()",
+    )
+    op.alter_column(
+        "sku_characteristics",
+        "id",
+        existing_type=sa.Integer(),
+        type_=uuid_type,
+        postgresql_using="gen_random_uuid()",
+    )
+    op.alter_column(
+        "sku_characteristics",
+        "sku_id",
+        existing_type=sa.Integer(),
+        type_=uuid_type,
+        postgresql_using="gen_random_uuid()",
+    )
+    op.alter_column(
+        "invoice_items",
+        "sku_id",
+        existing_type=sa.Integer(),
+        type_=uuid_type,
+        postgresql_using="gen_random_uuid()",
+    )
+
+    op.create_foreign_key(
+        "fk_products_category_id_categories",
+        "products",
+        "categories",
+        ["category_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+    op.create_foreign_key(
+        "fk_product_images_product_id_products",
+        "product_images",
+        "products",
+        ["product_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_foreign_key(
+        "fk_product_characteristics_product_id_products",
+        "product_characteristics",
+        "products",
+        ["product_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_foreign_key(
+        "fk_skus_product_id_products",
+        "skus",
+        "products",
+        ["product_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_foreign_key(
+        "fk_sku_characteristics_sku_id_skus",
+        "sku_characteristics",
+        "skus",
+        ["sku_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_foreign_key(
+        "fk_invoice_items_sku_id_skus",
+        "invoice_items",
+        "skus",
+        ["sku_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+
+
+def downgrade() -> None:
+    _drop_fk_if_exists("product_images", "fk_product_images_product_id_products", "product_images_product_id_fkey")
+    _drop_fk_if_exists(
+        "product_characteristics",
+        "fk_product_characteristics_product_id_products",
+        "product_characteristics_product_id_fkey",
+    )
+    _drop_fk_if_exists("skus", "fk_skus_product_id_products", "skus_product_id_fkey")
+    _drop_fk_if_exists(
+        "sku_characteristics",
+        "fk_sku_characteristics_sku_id_skus",
+        "sku_characteristics_sku_id_fkey",
+    )
+    _drop_fk_if_exists("invoice_items", "fk_invoice_items_sku_id_skus", "invoice_items_sku_id_fkey")
+    _drop_fk_if_exists("products", "fk_products_category_id_categories", "products_category_id_fkey")
+
+    op.alter_column(
+        "categories",
+        "id",
+        existing_type=uuid_type,
+        type_=sa.Integer(),
+        postgresql_using=(
+            "CASE name "
+            "WHEN 'Smartphones' THEN 1 "
+            "WHEN 'Laptops' THEN 2 "
+            "WHEN 'Accessories' THEN 3 "
+            "ELSE abs(hashtext(id::text)) END"
+        ),
+    )
+    op.alter_column(
+        "products",
+        "id",
+        existing_type=uuid_type,
+        type_=sa.Integer(),
+        postgresql_using="abs(hashtext(id::text))",
+    )
+    op.alter_column(
+        "products",
+        "category_id",
+        existing_type=uuid_type,
+        type_=sa.Integer(),
+        postgresql_using="abs(hashtext(category_id::text))",
+    )
+    op.alter_column(
+        "products",
+        "seller_id",
+        existing_type=uuid_type,
+        type_=sa.String(length=36),
+        postgresql_using="seller_id::text",
+    )
+    op.alter_column(
+        "product_images",
+        "id",
+        existing_type=uuid_type,
+        type_=sa.Integer(),
+        postgresql_using="abs(hashtext(id::text))",
+    )
+    op.alter_column(
+        "product_images",
+        "product_id",
+        existing_type=uuid_type,
+        type_=sa.Integer(),
+        postgresql_using="abs(hashtext(product_id::text))",
+    )
+    op.alter_column(
+        "product_characteristics",
+        "id",
+        existing_type=uuid_type,
+        type_=sa.Integer(),
+        postgresql_using="abs(hashtext(id::text))",
+    )
+    op.alter_column(
+        "product_characteristics",
+        "product_id",
+        existing_type=uuid_type,
+        type_=sa.Integer(),
+        postgresql_using="abs(hashtext(product_id::text))",
+    )
+    op.alter_column(
+        "skus",
+        "id",
+        existing_type=uuid_type,
+        type_=sa.Integer(),
+        postgresql_using="abs(hashtext(id::text))",
+    )
+    op.alter_column(
+        "skus",
+        "product_id",
+        existing_type=uuid_type,
+        type_=sa.Integer(),
+        postgresql_using="abs(hashtext(product_id::text))",
+    )
+    op.alter_column(
+        "sku_characteristics",
+        "id",
+        existing_type=uuid_type,
+        type_=sa.Integer(),
+        postgresql_using="abs(hashtext(id::text))",
+    )
+    op.alter_column(
+        "sku_characteristics",
+        "sku_id",
+        existing_type=uuid_type,
+        type_=sa.Integer(),
+        postgresql_using="abs(hashtext(sku_id::text))",
+    )
+    op.alter_column(
+        "invoice_items",
+        "sku_id",
+        existing_type=uuid_type,
+        type_=sa.Integer(),
+        postgresql_using="abs(hashtext(sku_id::text))",
+    )
+
+    op.create_foreign_key(
+        "fk_products_category_id_categories",
+        "products",
+        "categories",
+        ["category_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+    op.create_foreign_key(
+        "fk_product_images_product_id_products",
+        "product_images",
+        "products",
+        ["product_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_foreign_key(
+        "fk_product_characteristics_product_id_products",
+        "product_characteristics",
+        "products",
+        ["product_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_foreign_key(
+        "fk_skus_product_id_products",
+        "skus",
+        "products",
+        ["product_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_foreign_key(
+        "fk_sku_characteristics_sku_id_skus",
+        "sku_characteristics",
+        "skus",
+        ["sku_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_foreign_key(
+        "fk_invoice_items_sku_id_skus",
+        "invoice_items",
+        "skus",
+        ["sku_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ sqlalchemy>=2.0,<3.0
 psycopg[binary]>=3.2,<4.0
 alembic>=1.14,<2.0
 pydantic-settings>=2.6,<3.0
-
+pytest>=8.0,<9.0
+httpx>=0.27,<1.0

--- a/src/api/deps.py
+++ b/src/api/deps.py
@@ -4,6 +4,7 @@ import hashlib
 import hmac
 import json
 from typing import Any
+import uuid
 
 from fastapi import Depends
 from fastapi.responses import JSONResponse
@@ -16,7 +17,7 @@ oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/auth/login", auto_error=Fals
 
 @dataclass(frozen=True)
 class CurrentSeller:
-    seller_id: str
+    seller_id: uuid.UUID
 
 
 def unauthorized_response() -> JSONResponse:
@@ -64,4 +65,9 @@ def get_current_seller(token: str | None = Depends(oauth2_scheme)) -> CurrentSel
     if not isinstance(seller_id, str) or not seller_id.strip():
         return unauthorized_response()
 
-    return CurrentSeller(seller_id=seller_id)
+    try:
+        seller_uuid = uuid.UUID(seller_id)
+    except ValueError:
+        return unauthorized_response()
+
+    return CurrentSeller(seller_id=seller_uuid)

--- a/src/api/deps.py
+++ b/src/api/deps.py
@@ -1,0 +1,67 @@
+from dataclasses import dataclass
+import base64
+import hashlib
+import hmac
+import json
+from typing import Any
+
+from fastapi import Depends
+from fastapi.responses import JSONResponse
+from fastapi.security import OAuth2PasswordBearer
+
+from src.core.config import settings
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/auth/login", auto_error=False)
+
+
+@dataclass(frozen=True)
+class CurrentSeller:
+    seller_id: str
+
+
+def unauthorized_response() -> JSONResponse:
+    return JSONResponse(
+        status_code=401,
+        content={"code": "UNAUTHORIZED", "message": "Authorization required"},
+    )
+
+
+def _b64decode(value: str) -> bytes:
+    padding = "=" * (-len(value) % 4)
+    return base64.urlsafe_b64decode(f"{value}{padding}".encode("ascii"))
+
+
+def _decode_hs256_token(token: str) -> dict[str, Any] | None:
+    try:
+        header_raw, payload_raw, signature_raw = token.split(".")
+        header = json.loads(_b64decode(header_raw))
+        if header.get("alg") != settings.jwt_algorithm:
+            return None
+
+        signing_input = f"{header_raw}.{payload_raw}".encode("ascii")
+        expected_signature = hmac.new(
+            settings.jwt_secret_key.encode("utf-8"),
+            signing_input,
+            hashlib.sha256,
+        ).digest()
+        actual_signature = _b64decode(signature_raw)
+        if not hmac.compare_digest(expected_signature, actual_signature):
+            return None
+
+        payload = json.loads(_b64decode(payload_raw))
+    except (ValueError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+
+    return payload if isinstance(payload, dict) else None
+
+
+def get_current_seller(token: str | None = Depends(oauth2_scheme)) -> CurrentSeller | JSONResponse:
+    if not token:
+        return unauthorized_response()
+
+    payload = _decode_hs256_token(token)
+    seller_id = payload.get("seller_id") if payload else None
+    if not isinstance(seller_id, str) or not seller_id.strip():
+        return unauthorized_response()
+
+    return CurrentSeller(seller_id=seller_id)

--- a/src/api/routes/products.py
+++ b/src/api/routes/products.py
@@ -1,11 +1,10 @@
-from fastapi import APIRouter, Depends, Request, status
+from fastapi import APIRouter, Depends, status
 from fastapi.responses import JSONResponse
-from pydantic import ValidationError as PydanticValidationError
 from sqlalchemy.orm import Session
 
 from src.api.deps import CurrentSeller, get_current_seller
 from src.db.session import get_db
-from src.schemas.product import ProductCreate, ProductRead, ProductUpdate
+from src.schemas.product import ProductCreate, ProductCreateRead, ProductRead, ProductUpdate
 from src.services.product_service import (
     ProductCreateValidationError,
     create_product,
@@ -16,68 +15,34 @@ from src.services.product_service import (
 router = APIRouter(prefix="/api/v1/products", tags=["Products"])
 
 
-def _invalid_request(message: str) -> JSONResponse:
+def _field_validation_error(field: str, message: str) -> JSONResponse:
     return JSONResponse(
-        status_code=400,
-        content={"code": "INVALID_REQUEST", "message": message},
+        status_code=422,
+        content={
+            "detail": [
+                {
+                    "type": "value_error",
+                    "loc": ["body", field],
+                    "msg": message,
+                }
+            ]
+        },
     )
 
 
-def _product_validation_message(exc: PydanticValidationError) -> str:
-    error = exc.errors()[0] if exc.errors() else {}
-    loc = error.get("loc", ())
-    field = loc[-1] if loc else None
-
-    if field == "title":
-        return "title is required"
-    if field == "description":
-        return "description is required"
-    if field in {"category_id", "categoryId"}:
-        return "category_id must be valid"
-    return str(error.get("msg") or "Invalid product payload")
-
-
-async def _parse_product_create_payload(request: Request) -> ProductCreate | JSONResponse:
-    try:
-        body = await request.json()
-    except ValueError:
-        return _invalid_request("Invalid JSON body")
-
-    if not isinstance(body, dict):
-        return _invalid_request("Invalid product payload")
-
-    payload_data = dict(body)
-    payload_data.pop("seller_id", None)
-    payload_data.pop("sellerId", None)
-
-    if "category_id" not in payload_data and "categoryId" not in payload_data:
-        return _invalid_request("category_id is required")
-    if "images" not in payload_data or not payload_data["images"]:
-        return _invalid_request("At least one image is required")
-
-    try:
-        return ProductCreate.model_validate(payload_data)
-    except PydanticValidationError as exc:
-        return _invalid_request(_product_validation_message(exc))
-
-
-@router.post("", response_model=ProductRead, status_code=status.HTTP_201_CREATED)
+@router.post("", response_model=ProductCreateRead, status_code=status.HTTP_201_CREATED)
 async def create_product_endpoint(
-    request: Request,
+    payload: ProductCreate,
     current_seller: CurrentSeller | JSONResponse = Depends(get_current_seller),
     db: Session = Depends(get_db),
-) -> ProductRead | JSONResponse:
+) -> ProductCreateRead | JSONResponse:
     if isinstance(current_seller, JSONResponse):
         return current_seller
-
-    payload = await _parse_product_create_payload(request)
-    if isinstance(payload, JSONResponse):
-        return payload
 
     try:
         return create_product(db, payload, current_seller.seller_id)
     except ProductCreateValidationError as exc:
-        return _invalid_request(str(exc))
+        return _field_validation_error(exc.field, exc.message)
 
 
 @router.get("/{id}", response_model=ProductRead, status_code=status.HTTP_200_OK)

--- a/src/api/routes/products.py
+++ b/src/api/routes/products.py
@@ -1,16 +1,83 @@
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, Request, status
+from fastapi.responses import JSONResponse
+from pydantic import ValidationError as PydanticValidationError
 from sqlalchemy.orm import Session
 
+from src.api.deps import CurrentSeller, get_current_seller
 from src.db.session import get_db
 from src.schemas.product import ProductCreate, ProductRead, ProductUpdate
-from src.services.product_service import create_product, get_product_by_id, update_product
+from src.services.product_service import (
+    ProductCreateValidationError,
+    create_product,
+    get_product_by_id,
+    update_product,
+)
 
 router = APIRouter(prefix="/api/v1/products", tags=["Products"])
 
 
+def _invalid_request(message: str) -> JSONResponse:
+    return JSONResponse(
+        status_code=400,
+        content={"code": "INVALID_REQUEST", "message": message},
+    )
+
+
+def _product_validation_message(exc: PydanticValidationError) -> str:
+    error = exc.errors()[0] if exc.errors() else {}
+    loc = error.get("loc", ())
+    field = loc[-1] if loc else None
+
+    if field == "title":
+        return "title is required"
+    if field == "description":
+        return "description is required"
+    if field in {"category_id", "categoryId"}:
+        return "category_id must be valid"
+    return str(error.get("msg") or "Invalid product payload")
+
+
+async def _parse_product_create_payload(request: Request) -> ProductCreate | JSONResponse:
+    try:
+        body = await request.json()
+    except ValueError:
+        return _invalid_request("Invalid JSON body")
+
+    if not isinstance(body, dict):
+        return _invalid_request("Invalid product payload")
+
+    payload_data = dict(body)
+    payload_data.pop("seller_id", None)
+    payload_data.pop("sellerId", None)
+
+    if "category_id" not in payload_data and "categoryId" not in payload_data:
+        return _invalid_request("category_id is required")
+    if "images" not in payload_data or not payload_data["images"]:
+        return _invalid_request("At least one image is required")
+
+    try:
+        return ProductCreate.model_validate(payload_data)
+    except PydanticValidationError as exc:
+        return _invalid_request(_product_validation_message(exc))
+
+
 @router.post("", response_model=ProductRead, status_code=status.HTTP_201_CREATED)
-def create_product_endpoint(payload: ProductCreate, db: Session = Depends(get_db)) -> ProductRead:
-    return create_product(db, payload)
+async def create_product_endpoint(
+    request: Request,
+    current_seller: CurrentSeller | JSONResponse = Depends(get_current_seller),
+    db: Session = Depends(get_db),
+) -> ProductRead | JSONResponse:
+    if isinstance(current_seller, JSONResponse):
+        return current_seller
+
+    payload = await _parse_product_create_payload(request)
+    if isinstance(payload, JSONResponse):
+        return payload
+
+    try:
+        return create_product(db, payload, current_seller.seller_id)
+    except ProductCreateValidationError as exc:
+        return _invalid_request(str(exc))
 
 
 @router.get("/{id}", response_model=ProductRead, status_code=status.HTTP_200_OK)
@@ -25,4 +92,3 @@ def update_product_endpoint(
     db: Session = Depends(get_db),
 ) -> ProductRead:
     return update_product(db, id, payload)
-

--- a/src/api/routes/products.py
+++ b/src/api/routes/products.py
@@ -1,3 +1,5 @@
+import uuid
+
 from fastapi import APIRouter, Depends, status
 from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
@@ -18,15 +20,7 @@ router = APIRouter(prefix="/api/v1/products", tags=["Products"])
 def _field_validation_error(field: str, message: str) -> JSONResponse:
     return JSONResponse(
         status_code=422,
-        content={
-            "detail": [
-                {
-                    "type": "value_error",
-                    "loc": ["body", field],
-                    "msg": message,
-                }
-            ]
-        },
+        content={"code": "VALIDATION_ERROR", "message": f"{field}: {message}"},
     )
 
 
@@ -55,13 +49,13 @@ async def create_product_endpoint(
 
 
 @router.get("/{id}", response_model=ProductRead, status_code=status.HTTP_200_OK)
-def get_product_endpoint(id: int, db: Session = Depends(get_db)) -> ProductRead:
+def get_product_endpoint(id: uuid.UUID, db: Session = Depends(get_db)) -> ProductRead:
     return get_product_by_id(db, id)
 
 
 @router.put("/{id}", response_model=ProductRead, status_code=status.HTTP_200_OK)
 def update_product_endpoint(
-    id: int,
+    id: uuid.UUID,
     payload: ProductUpdate,
     db: Session = Depends(get_db),
 ) -> ProductRead:

--- a/src/api/routes/products.py
+++ b/src/api/routes/products.py
@@ -30,6 +30,13 @@ def _field_validation_error(field: str, message: str) -> JSONResponse:
     )
 
 
+def _invalid_request(message: str) -> JSONResponse:
+    return JSONResponse(
+        status_code=400,
+        content={"code": "INVALID_REQUEST", "message": message},
+    )
+
+
 @router.post("", response_model=ProductCreateRead, status_code=status.HTTP_201_CREATED)
 async def create_product_endpoint(
     payload: ProductCreate,
@@ -42,6 +49,8 @@ async def create_product_endpoint(
     try:
         return create_product(db, payload, current_seller.seller_id)
     except ProductCreateValidationError as exc:
+        if exc.field == "images":
+            return _invalid_request(exc.message)
         return _field_validation_error(exc.field, exc.message)
 
 

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -15,6 +15,9 @@ class Settings(BaseSettings):
     db_password: str = "postgres"
     db_echo: bool = False
 
+    jwt_secret_key: str = "dev-secret"
+    jwt_algorithm: str = "HS256"
+
     model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",

--- a/src/db/types.py
+++ b/src/db/types.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import CHAR
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.types import TypeDecorator
+
+
+class GUID(TypeDecorator):
+    """Platform-independent UUID type.
+
+    PostgreSQL stores native UUID values. SQLite stores canonical UUID strings.
+    Python-side values are always uuid.UUID instances.
+    """
+
+    impl = CHAR
+    cache_ok = True
+
+    def load_dialect_impl(self, dialect):
+        if dialect.name == "postgresql":
+            return dialect.type_descriptor(UUID(as_uuid=True))
+        return dialect.type_descriptor(CHAR(36))
+
+    def process_bind_param(self, value, dialect):
+        if value is None:
+            return None
+        if not isinstance(value, uuid.UUID):
+            value = uuid.UUID(str(value))
+        if dialect.name == "postgresql":
+            return value
+        return str(value)
+
+    def process_result_value(self, value, dialect):
+        if value is None:
+            return None
+        if isinstance(value, uuid.UUID):
+            return value
+        return uuid.UUID(str(value))

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 
 from src.api.router import api_router
@@ -20,15 +21,27 @@ def healthcheck() -> dict[str, str]:
 
 @app.exception_handler(NotFoundError)
 async def not_found_exception_handler(_, exc: NotFoundError) -> JSONResponse:
-    return JSONResponse(status_code=404, content={"detail": str(exc)})
+    return JSONResponse(status_code=404, content={"code": "NOT_FOUND", "message": str(exc)})
+
+
+@app.exception_handler(RequestValidationError)
+async def request_validation_exception_handler(_, exc: RequestValidationError) -> JSONResponse:
+    first_error = exc.errors()[0] if exc.errors() else {}
+    location = first_error.get("loc", ())
+    field = location[-1] if location else "request"
+    message = first_error.get("msg", "Request validation failed")
+    return JSONResponse(
+        status_code=422,
+        content={"code": "VALIDATION_ERROR", "message": f"{field}: {message}"},
+    )
 
 
 @app.exception_handler(ValidationError)
 async def validation_exception_handler(_, exc: ValidationError) -> JSONResponse:
-    return JSONResponse(status_code=400, content={"detail": str(exc)})
+    return JSONResponse(status_code=400, content={"code": "INVALID_REQUEST", "message": str(exc)})
 
 
 @app.exception_handler(ConflictError)
 async def conflict_exception_handler(_, exc: ConflictError) -> JSONResponse:
-    return JSONResponse(status_code=409, content={"detail": str(exc)})
+    return JSONResponse(status_code=409, content={"code": "CONFLICT", "message": str(exc)})
 

--- a/src/models/category.py
+++ b/src/models/category.py
@@ -1,15 +1,17 @@
 from datetime import datetime
+import uuid
 
 from sqlalchemy import DateTime, String, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
+from src.db.types import GUID
 from src.models.base import Base
 
 
 class Category(Base):
     __tablename__ = "categories"
 
-    id: Mapped[int] = mapped_column(primary_key=True)
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
     name: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),

--- a/src/models/invoice.py
+++ b/src/models/invoice.py
@@ -1,9 +1,11 @@
 from datetime import datetime
 from enum import Enum
+import uuid
 
 from sqlalchemy import DateTime, Enum as SqlEnum, ForeignKey, Integer, String, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
+from src.db.types import GUID
 from src.models.base import Base
 
 
@@ -43,7 +45,7 @@ class InvoiceItem(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     invoice_id: Mapped[int] = mapped_column(ForeignKey("invoices.id", ondelete="CASCADE"))
-    sku_id: Mapped[int] = mapped_column(ForeignKey("skus.id", ondelete="RESTRICT"))
+    sku_id: Mapped[uuid.UUID] = mapped_column(GUID(), ForeignKey("skus.id", ondelete="RESTRICT"))
     quantity: Mapped[int] = mapped_column(Integer, nullable=False)
 
     invoice = relationship("Invoice", back_populates="items")

--- a/src/models/product.py
+++ b/src/models/product.py
@@ -1,9 +1,11 @@
 from datetime import datetime
 from enum import Enum
+import uuid
 
 from sqlalchemy import DateTime, Enum as SqlEnum, ForeignKey, Integer, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
+from src.db.types import GUID
 from src.models.base import Base
 
 
@@ -18,7 +20,7 @@ class ProductStatus(str, Enum):
 class Product(Base):
     __tablename__ = "products"
 
-    id: Mapped[int] = mapped_column(primary_key=True)
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
     title: Mapped[str] = mapped_column(String(255), nullable=False)
     description: Mapped[str] = mapped_column(Text, nullable=False)
     status: Mapped[ProductStatus] = mapped_column(
@@ -26,8 +28,8 @@ class Product(Base):
         nullable=False,
         default=ProductStatus.CREATED,
     )
-    seller_id: Mapped[str] = mapped_column(String(36), nullable=False)
-    category_id: Mapped[int] = mapped_column(ForeignKey("categories.id", ondelete="RESTRICT"))
+    seller_id: Mapped[uuid.UUID] = mapped_column(GUID(), nullable=False)
+    category_id: Mapped[uuid.UUID] = mapped_column(GUID(), ForeignKey("categories.id", ondelete="RESTRICT"))
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         server_default=func.now(),
@@ -58,8 +60,8 @@ class Product(Base):
 class ProductImage(Base):
     __tablename__ = "product_images"
 
-    id: Mapped[int] = mapped_column(primary_key=True)
-    product_id: Mapped[int] = mapped_column(ForeignKey("products.id", ondelete="CASCADE"))
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
+    product_id: Mapped[uuid.UUID] = mapped_column(GUID(), ForeignKey("products.id", ondelete="CASCADE"))
     url: Mapped[str] = mapped_column(String(1024), nullable=False)
     ordering: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
 
@@ -69,8 +71,8 @@ class ProductImage(Base):
 class ProductCharacteristic(Base):
     __tablename__ = "product_characteristics"
 
-    id: Mapped[int] = mapped_column(primary_key=True)
-    product_id: Mapped[int] = mapped_column(ForeignKey("products.id", ondelete="CASCADE"))
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
+    product_id: Mapped[uuid.UUID] = mapped_column(GUID(), ForeignKey("products.id", ondelete="CASCADE"))
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     value: Mapped[str] = mapped_column(String(255), nullable=False)
 

--- a/src/models/product.py
+++ b/src/models/product.py
@@ -8,6 +8,7 @@ from src.models.base import Base
 
 
 class ProductStatus(str, Enum):
+    CREATED = "CREATED"
     DRAFT = "DRAFT"
     ON_MODERATION = "ON_MODERATION"
     MODERATED = "MODERATED"
@@ -23,8 +24,9 @@ class Product(Base):
     status: Mapped[ProductStatus] = mapped_column(
         SqlEnum(ProductStatus, name="product_status"),
         nullable=False,
-        default=ProductStatus.DRAFT,
+        default=ProductStatus.CREATED,
     )
+    seller_id: Mapped[str] = mapped_column(String(36), nullable=False)
     category_id: Mapped[int] = mapped_column(ForeignKey("categories.id", ondelete="RESTRICT"))
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),

--- a/src/models/sku.py
+++ b/src/models/sku.py
@@ -1,16 +1,18 @@
 from datetime import datetime
+import uuid
 
 from sqlalchemy import DateTime, ForeignKey, Integer, String, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
+from src.db.types import GUID
 from src.models.base import Base
 
 
 class SKU(Base):
     __tablename__ = "skus"
 
-    id: Mapped[int] = mapped_column(primary_key=True)
-    product_id: Mapped[int] = mapped_column(ForeignKey("products.id", ondelete="CASCADE"))
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
+    product_id: Mapped[uuid.UUID] = mapped_column(GUID(), ForeignKey("products.id", ondelete="CASCADE"))
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     price: Mapped[int] = mapped_column(Integer, nullable=False)
     active_quantity: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
@@ -38,8 +40,8 @@ class SKU(Base):
 class SKUCharacteristic(Base):
     __tablename__ = "sku_characteristics"
 
-    id: Mapped[int] = mapped_column(primary_key=True)
-    sku_id: Mapped[int] = mapped_column(ForeignKey("skus.id", ondelete="CASCADE"))
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
+    sku_id: Mapped[uuid.UUID] = mapped_column(GUID(), ForeignKey("skus.id", ondelete="CASCADE"))
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     value: Mapped[str] = mapped_column(String(255), nullable=False)
 

--- a/src/schemas/common.py
+++ b/src/schemas/common.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_serializer
 
 
 class APIModel(BaseModel):
@@ -20,7 +20,11 @@ class ImagePayload(APIModel):
 
 
 class ImageOut(ImagePayload):
-    pass
+    id: int
+
+    @field_serializer("id")
+    def serialize_id(self, value: int) -> str:
+        return str(value)
 
 
 class CharacteristicPayload(APIModel):
@@ -29,5 +33,9 @@ class CharacteristicPayload(APIModel):
 
 
 class CharacteristicOut(CharacteristicPayload):
-    pass
+    id: int
+
+    @field_serializer("id")
+    def serialize_id(self, value: int) -> str:
+        return str(value)
 

--- a/src/schemas/common.py
+++ b/src/schemas/common.py
@@ -1,4 +1,6 @@
-from pydantic import BaseModel, ConfigDict, field_serializer
+import uuid
+
+from pydantic import BaseModel, ConfigDict
 
 
 class APIModel(BaseModel):
@@ -10,7 +12,7 @@ class APIModel(BaseModel):
 
 
 class CategoryOut(APIModel):
-    id: int
+    id: uuid.UUID
     name: str
 
 
@@ -20,11 +22,7 @@ class ImagePayload(APIModel):
 
 
 class ImageOut(ImagePayload):
-    id: int
-
-    @field_serializer("id")
-    def serialize_id(self, value: int) -> str:
-        return str(value)
+    id: uuid.UUID
 
 
 class CharacteristicPayload(APIModel):
@@ -33,9 +31,5 @@ class CharacteristicPayload(APIModel):
 
 
 class CharacteristicOut(CharacteristicPayload):
-    id: int
-
-    @field_serializer("id")
-    def serialize_id(self, value: int) -> str:
-        return str(value)
+    id: uuid.UUID
 

--- a/src/schemas/invoice.py
+++ b/src/schemas/invoice.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import uuid
 
 from pydantic import AliasChoices, Field
 
@@ -6,7 +7,7 @@ from src.schemas.common import APIModel
 
 
 class InvoiceItemCreate(APIModel):
-    sku_id: int = Field(validation_alias=AliasChoices("sku_id", "skuId"))
+    sku_id: uuid.UUID = Field(validation_alias=AliasChoices("sku_id", "skuId"))
     quantity: int = Field(gt=0)
 
 
@@ -20,7 +21,7 @@ class InvoiceAccept(APIModel):
 
 
 class InvoiceItemRead(APIModel):
-    sku_id: int = Field(serialization_alias="skuId")
+    sku_id: uuid.UUID = Field(serialization_alias="skuId")
     quantity: int
 
 

--- a/src/schemas/product.py
+++ b/src/schemas/product.py
@@ -8,7 +8,6 @@ from src.schemas.common import (
     CategoryOut,
     CharacteristicOut,
     CharacteristicPayload,
-    ImageOut,
     ImagePayload,
 )
 
@@ -32,6 +31,22 @@ class ProductUpdate(APIModel):
     characteristics: list[CharacteristicPayload] | None = None
 
 
+class ProductImageOut(ImagePayload):
+    id: int
+
+    @field_serializer("id")
+    def serialize_id(self, value: int) -> str:
+        return str(value)
+
+
+class ProductCharacteristicOut(CharacteristicPayload):
+    id: int
+
+    @field_serializer("id")
+    def serialize_id(self, value: int) -> str:
+        return str(value)
+
+
 class ProductSKURead(APIModel):
     id: int
     name: str
@@ -48,8 +63,8 @@ class ProductRead(APIModel):
     description: str
     status: str
     category: CategoryOut
-    images: list[ImageOut] = Field(default_factory=list)
-    characteristics: list[CharacteristicOut] = Field(default_factory=list)
+    images: list[ProductImageOut] = Field(default_factory=list)
+    characteristics: list[ProductCharacteristicOut] = Field(default_factory=list)
     skus: list[ProductSKURead] = Field(default_factory=list)
     created_at: datetime
     updated_at: datetime

--- a/src/schemas/product.py
+++ b/src/schemas/product.py
@@ -8,6 +8,7 @@ from src.schemas.common import (
     CategoryOut,
     CharacteristicOut,
     CharacteristicPayload,
+    ImageOut,
     ImagePayload,
 )
 
@@ -31,22 +32,6 @@ class ProductUpdate(APIModel):
     characteristics: list[CharacteristicPayload] | None = None
 
 
-class ProductImageOut(ImagePayload):
-    id: int
-
-    @field_serializer("id")
-    def serialize_id(self, value: int) -> str:
-        return str(value)
-
-
-class ProductCharacteristicOut(CharacteristicPayload):
-    id: int
-
-    @field_serializer("id")
-    def serialize_id(self, value: int) -> str:
-        return str(value)
-
-
 class ProductSKURead(APIModel):
     id: int
     name: str
@@ -63,8 +48,8 @@ class ProductRead(APIModel):
     description: str
     status: str
     category: CategoryOut
-    images: list[ProductImageOut] = Field(default_factory=list)
-    characteristics: list[ProductCharacteristicOut] = Field(default_factory=list)
+    images: list[ImageOut] = Field(default_factory=list)
+    characteristics: list[CharacteristicOut] = Field(default_factory=list)
     skus: list[ProductSKURead] = Field(default_factory=list)
     created_at: datetime
     updated_at: datetime

--- a/src/schemas/product.py
+++ b/src/schemas/product.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from pydantic import AliasChoices, Field
 
 from src.schemas.common import (
@@ -11,8 +13,8 @@ from src.schemas.common import (
 
 
 class ProductCreate(APIModel):
-    title: str
-    description: str
+    title: str = Field(min_length=1, max_length=255)
+    description: str = Field(min_length=1, max_length=5000)
     category_id: int = Field(validation_alias=AliasChoices("category_id", "categoryId"))
     images: list[ImagePayload] = Field(default_factory=list)
     characteristics: list[CharacteristicPayload] = Field(default_factory=list)
@@ -39,6 +41,8 @@ class ProductSKURead(APIModel):
 
 class ProductRead(APIModel):
     id: int
+    seller_id: str
+    category_id: int
     title: str
     description: str
     status: str
@@ -46,4 +50,6 @@ class ProductRead(APIModel):
     images: list[ImageOut] = Field(default_factory=list)
     characteristics: list[CharacteristicOut] = Field(default_factory=list)
     skus: list[ProductSKURead] = Field(default_factory=list)
+    created_at: datetime
+    updated_at: datetime
 

--- a/src/schemas/product.py
+++ b/src/schemas/product.py
@@ -1,6 +1,7 @@
+import re
 from datetime import datetime
 
-from pydantic import AliasChoices, Field
+from pydantic import AliasChoices, Field, computed_field, field_serializer
 
 from src.schemas.common import (
     APIModel,
@@ -52,4 +53,20 @@ class ProductRead(APIModel):
     skus: list[ProductSKURead] = Field(default_factory=list)
     created_at: datetime
     updated_at: datetime
+
+
+class ProductCreateRead(ProductRead):
+    deleted: bool = False
+    blocking_reason_id: str | None = None
+    moderator_comment: str | None = None
+
+    @computed_field
+    @property
+    def slug(self) -> str:
+        value = re.sub(r"[^a-z0-9]+", "-", self.title.lower()).strip("-")
+        return f"{value or 'product'}-{self.id}"
+
+    @field_serializer("id", "category_id")
+    def serialize_id(self, value: int) -> str:
+        return str(value)
 

--- a/src/schemas/product.py
+++ b/src/schemas/product.py
@@ -1,7 +1,9 @@
 import re
 from datetime import datetime
+from typing import Any
+import uuid
 
-from pydantic import AliasChoices, Field, computed_field, field_serializer
+from pydantic import AliasChoices, Field, computed_field, model_validator
 
 from src.schemas.common import (
     APIModel,
@@ -12,11 +14,13 @@ from src.schemas.common import (
     ImagePayload,
 )
 
+SKU_IMAGE_NAMESPACE = uuid.UUID("ec18e7b4-9898-5d27-a588-cf5810cb78bd")
+
 
 class ProductCreate(APIModel):
     title: str = Field(min_length=1, max_length=255)
     description: str = Field(min_length=1, max_length=5000)
-    category_id: int = Field(validation_alias=AliasChoices("category_id", "categoryId"))
+    category_id: uuid.UUID = Field(validation_alias=AliasChoices("category_id", "categoryId"))
     images: list[ImagePayload] = Field(default_factory=list)
     characteristics: list[CharacteristicPayload] = Field(default_factory=list)
 
@@ -24,7 +28,7 @@ class ProductCreate(APIModel):
 class ProductUpdate(APIModel):
     title: str | None = None
     description: str | None = None
-    category_id: int | None = Field(
+    category_id: uuid.UUID | None = Field(
         default=None,
         validation_alias=AliasChoices("category_id", "categoryId"),
     )
@@ -33,17 +37,58 @@ class ProductUpdate(APIModel):
 
 
 class ProductSKURead(APIModel):
-    id: int
+    id: uuid.UUID
+    product_id: uuid.UUID
     name: str
     price: int
-    active_quantity: int = Field(serialization_alias="activeQuantity")
+    discount: int = 0
+    cost_price: int = 0
+    stock_quantity: int = 0
+    reserved_quantity: int = 0
+    article: str | None = None
+    active_quantity: int
+    images: list[ImageOut] = Field(default_factory=list)
     characteristics: list[CharacteristicOut] = Field(default_factory=list)
+    created_at: datetime
+    updated_at: datetime
+
+    @model_validator(mode="before")
+    @classmethod
+    def add_synthetic_images(cls, value: Any) -> Any:
+        image = value.get("image") if isinstance(value, dict) else getattr(value, "image", None)
+        if not image:
+            return value
+
+        sku_id = value.get("id") if isinstance(value, dict) else getattr(value, "id")
+        image_id = uuid.uuid5(SKU_IMAGE_NAMESPACE, f"sku-image:{sku_id}:0")
+
+        if isinstance(value, dict):
+            value = value.copy()
+            value.setdefault("images", [{"id": image_id, "url": image, "ordering": 0}])
+            return value
+
+        return {
+            "id": value.id,
+            "product_id": value.product_id,
+            "name": value.name,
+            "price": value.price,
+            "discount": getattr(value, "discount", 0),
+            "cost_price": getattr(value, "cost_price", 0),
+            "stock_quantity": getattr(value, "stock_quantity", 0),
+            "active_quantity": value.active_quantity,
+            "reserved_quantity": getattr(value, "reserved_quantity", 0),
+            "article": getattr(value, "article", None),
+            "images": [{"id": image_id, "url": image, "ordering": 0}],
+            "characteristics": getattr(value, "characteristics", []),
+            "created_at": value.created_at,
+            "updated_at": value.updated_at,
+        }
 
 
 class ProductRead(APIModel):
-    id: int
-    seller_id: str
-    category_id: int
+    id: uuid.UUID
+    seller_id: uuid.UUID
+    category_id: uuid.UUID
     title: str
     description: str
     status: str
@@ -53,9 +98,6 @@ class ProductRead(APIModel):
     skus: list[ProductSKURead] = Field(default_factory=list)
     created_at: datetime
     updated_at: datetime
-
-
-class ProductCreateRead(ProductRead):
     deleted: bool = False
     blocking_reason_id: str | None = None
     moderator_comment: str | None = None
@@ -66,7 +108,7 @@ class ProductCreateRead(ProductRead):
         value = re.sub(r"[^a-z0-9]+", "-", self.title.lower()).strip("-")
         return f"{value or 'product'}-{self.id}"
 
-    @field_serializer("id", "category_id")
-    def serialize_id(self, value: int) -> str:
-        return str(value)
+
+class ProductCreateRead(ProductRead):
+    pass
 

--- a/src/schemas/sku.py
+++ b/src/schemas/sku.py
@@ -1,39 +1,39 @@
+import uuid
+
 from pydantic import AliasChoices, Field
 
 from src.schemas.common import APIModel, CharacteristicOut, CharacteristicPayload
 
 
 class SKUCreate(APIModel):
-    product_id: int = Field(validation_alias=AliasChoices("product_id", "productId"))
+    product_id: uuid.UUID = Field(validation_alias=AliasChoices("product_id", "productId"))
     name: str
     price: int = Field(ge=0)
     active_quantity: int = Field(
         default=0,
         ge=0,
         validation_alias=AliasChoices("active_quantity", "activeQuantity"),
-        serialization_alias="activeQuantity",
     )
     characteristics: list[CharacteristicPayload] = Field(default_factory=list)
 
 
 class SKUUpdate(APIModel):
-    id: int
+    id: uuid.UUID
     name: str | None = None
     price: int | None = Field(default=None, ge=0)
     active_quantity: int | None = Field(
         default=None,
         ge=0,
         validation_alias=AliasChoices("active_quantity", "activeQuantity"),
-        serialization_alias="activeQuantity",
     )
     characteristics: list[CharacteristicPayload] | None = None
 
 
 class SKURead(APIModel):
-    id: int
-    product_id: int = Field(serialization_alias="productId")
+    id: uuid.UUID
+    product_id: uuid.UUID
     name: str
     price: int
-    active_quantity: int = Field(serialization_alias="activeQuantity")
+    active_quantity: int
     characteristics: list[CharacteristicOut] = Field(default_factory=list)
 

--- a/src/services/product_service.py
+++ b/src/services/product_service.py
@@ -1,3 +1,5 @@
+import uuid
+
 from sqlalchemy import select
 from sqlalchemy.orm import Session, selectinload
 
@@ -25,21 +27,21 @@ def _product_query():
     )
 
 
-def _get_category_or_raise(db: Session, category_id: int) -> Category:
+def _get_category_or_raise(db: Session, category_id: uuid.UUID) -> Category:
     category = db.get(Category, category_id)
     if category is None:
         raise NotFoundError(f"Category with id={category_id} not found")
     return category
 
 
-def get_product_by_id(db: Session, product_id: int) -> Product:
+def get_product_by_id(db: Session, product_id: uuid.UUID) -> Product:
     product = db.scalars(_product_query().where(Product.id == product_id)).first()
     if product is None:
         raise NotFoundError(f"Product with id={product_id} not found")
     return product
 
 
-def create_product(db: Session, payload: ProductCreate, seller_id: str) -> Product:
+def create_product(db: Session, payload: ProductCreate, seller_id: uuid.UUID) -> Product:
     if not payload.images:
         raise ProductCreateValidationError("images", "At least one image is required")
 
@@ -63,7 +65,7 @@ def create_product(db: Session, payload: ProductCreate, seller_id: str) -> Produ
     return get_product_by_id(db, product.id)
 
 
-def update_product(db: Session, product_id: int, payload: ProductUpdate) -> Product:
+def update_product(db: Session, product_id: uuid.UUID, payload: ProductUpdate) -> Product:
     product = get_product_by_id(db, product_id)
 
     if payload.title is not None:

--- a/src/services/product_service.py
+++ b/src/services/product_service.py
@@ -7,7 +7,10 @@ from src.services.errors import NotFoundError
 
 
 class ProductCreateValidationError(Exception):
-    pass
+    def __init__(self, field: str, message: str) -> None:
+        self.field = field
+        self.message = message
+        super().__init__(message)
 
 
 def _product_query():
@@ -37,10 +40,8 @@ def get_product_by_id(db: Session, product_id: int) -> Product:
 
 
 def create_product(db: Session, payload: ProductCreate, seller_id: str) -> Product:
-    if not payload.images:
-        raise ProductCreateValidationError("At least one image is required")
     if db.get(Category, payload.category_id) is None:
-        raise ProductCreateValidationError("Category not found")
+        raise ProductCreateValidationError("category_id", "Category not found")
 
     product = Product(
         title=payload.title,

--- a/src/services/product_service.py
+++ b/src/services/product_service.py
@@ -1,9 +1,13 @@
 from sqlalchemy import select
 from sqlalchemy.orm import Session, selectinload
 
-from src.models import Category, Product, ProductCharacteristic, ProductImage, SKU
+from src.models import Category, Product, ProductCharacteristic, ProductImage, ProductStatus, SKU
 from src.schemas.product import ProductCreate, ProductUpdate
 from src.services.errors import NotFoundError
+
+
+class ProductCreateValidationError(Exception):
+    pass
 
 
 def _product_query():
@@ -32,13 +36,18 @@ def get_product_by_id(db: Session, product_id: int) -> Product:
     return product
 
 
-def create_product(db: Session, payload: ProductCreate) -> Product:
-    _get_category_or_raise(db, payload.category_id)
+def create_product(db: Session, payload: ProductCreate, seller_id: str) -> Product:
+    if not payload.images:
+        raise ProductCreateValidationError("At least one image is required")
+    if db.get(Category, payload.category_id) is None:
+        raise ProductCreateValidationError("Category not found")
 
     product = Product(
         title=payload.title,
         description=payload.description,
         category_id=payload.category_id,
+        seller_id=seller_id,
+        status=ProductStatus.CREATED,
     )
     product.images = [ProductImage(url=image.url, ordering=image.ordering) for image in payload.images]
     product.characteristics = [

--- a/src/services/product_service.py
+++ b/src/services/product_service.py
@@ -40,6 +40,9 @@ def get_product_by_id(db: Session, product_id: int) -> Product:
 
 
 def create_product(db: Session, payload: ProductCreate, seller_id: str) -> Product:
+    if not payload.images:
+        raise ProductCreateValidationError("images", "At least one image is required")
+
     if db.get(Category, payload.category_id) is None:
         raise ProductCreateValidationError("category_id", "Category not found")
 

--- a/src/services/sku_service.py
+++ b/src/services/sku_service.py
@@ -1,3 +1,5 @@
+import uuid
+
 from sqlalchemy import select
 from sqlalchemy.orm import Session, selectinload
 
@@ -10,14 +12,14 @@ def _sku_query():
     return select(SKU).options(selectinload(SKU.characteristics))
 
 
-def _get_product_or_raise(db: Session, product_id: int) -> Product:
+def _get_product_or_raise(db: Session, product_id: uuid.UUID) -> Product:
     product = db.get(Product, product_id)
     if product is None:
         raise NotFoundError(f"Product with id={product_id} not found")
     return product
 
 
-def _get_sku_or_raise(db: Session, sku_id: int) -> SKU:
+def _get_sku_or_raise(db: Session, sku_id: uuid.UUID) -> SKU:
     sku = db.scalars(_sku_query().where(SKU.id == sku_id)).first()
     if sku is None:
         raise NotFoundError(f"SKU with id={sku_id} not found")

--- a/tests/api/test_products.py
+++ b/tests/api/test_products.py
@@ -23,7 +23,12 @@ def test_create_product_returns_201_with_created_status(client, category_factory
     assert body["category_id"] == str(category.id)
     assert body["status"] == "CREATED"
     assert body["skus"] == []
-    assert body["images"] == payload["images"]
+    assert body["images"][0]["id"]
+    assert body["images"][0]["url"] == payload["images"][0]["url"]
+    assert body["images"][0]["ordering"] == payload["images"][0]["ordering"]
+    assert body["characteristics"][0]["id"]
+    assert body["characteristics"][0]["name"] == payload["characteristics"][0]["name"]
+    assert body["characteristics"][0]["value"] == payload["characteristics"][0]["value"]
     assert body["seller_id"] == "c3d4e5f6-a7b8-9012-cdef-123456789012"
     assert body["slug"] == f"iphone-15-pro-max-{body['id']}"
     assert body["deleted"] is False
@@ -57,7 +62,7 @@ def test_seller_id_taken_from_jwt(
     assert product.seller_id == jwt_seller_id
 
 
-def test_create_product_without_images_returns_201_with_empty_images(
+def test_missing_images_returns_400(
     client,
     category_factory,
     product_payload_factory,
@@ -69,14 +74,14 @@ def test_create_product_without_images_returns_201_with_empty_images(
 
     response = client.post("/api/v1/products", json=payload, headers=auth_headers())
 
-    assert response.status_code == 201
-    assert response.json()["images"] == []
+    assert response.status_code == 400
+    assert response.json() == {"code": "INVALID_REQUEST", "message": "At least one image is required"}
 
     payload = product_payload_factory(category.id, images=[])
     response = client.post("/api/v1/products", json=payload, headers=auth_headers())
 
-    assert response.status_code == 201
-    assert response.json()["images"] == []
+    assert response.status_code == 400
+    assert response.json() == {"code": "INVALID_REQUEST", "message": "At least one image is required"}
 
 
 def test_missing_category_returns_422_with_field_details(client, category_factory, product_payload_factory, auth_headers):

--- a/tests/api/test_products.py
+++ b/tests/api/test_products.py
@@ -1,13 +1,29 @@
+from uuid import UUID, uuid4
+
 from sqlalchemy.orm import Session
 
-from src.models import Product
+from src.models import Product, ProductCharacteristic, ProductImage, ProductStatus, SKU, SKUCharacteristic
 
 
-def _assert_category_validation_detail(response):
+def _assert_validation_error(response):
     assert response.status_code == 422
-    detail = response.json()["detail"]
-    assert isinstance(detail, list)
-    assert detail[0]["loc"][-1] == "category_id"
+    body = response.json()
+    assert body["code"] == "VALIDATION_ERROR"
+    assert "detail" not in body
+    assert body["message"]
+
+
+def _assert_uuid(value: str) -> UUID:
+    parsed = UUID(value)
+    assert value not in {"1", "2", "3"}
+    return parsed
+
+
+def _assert_product_response_contract(body: dict) -> None:
+    assert body["slug"] == f"iphone-15-pro-max-{body['id']}"
+    assert body["deleted"] is False
+    assert body["blocking_reason_id"] is None
+    assert body["moderator_comment"] is None
 
 
 def test_create_product_returns_201_with_created_status(client, category_factory, product_payload_factory, auth_headers):
@@ -21,6 +37,7 @@ def test_create_product_returns_201_with_created_status(client, category_factory
     assert body["title"] == payload["title"]
     assert body["description"] == payload["description"]
     assert body["category_id"] == str(category.id)
+    assert body["category"]["id"] == str(category.id)
     assert body["status"] == "CREATED"
     assert body["skus"] == []
     assert body["images"][0]["id"]
@@ -30,12 +47,14 @@ def test_create_product_returns_201_with_created_status(client, category_factory
     assert body["characteristics"][0]["name"] == payload["characteristics"][0]["name"]
     assert body["characteristics"][0]["value"] == payload["characteristics"][0]["value"]
     assert body["seller_id"] == "c3d4e5f6-a7b8-9012-cdef-123456789012"
-    assert body["slug"] == f"iphone-15-pro-max-{body['id']}"
-    assert body["deleted"] is False
-    assert body["blocking_reason_id"] is None
-    assert body["moderator_comment"] is None
+    _assert_product_response_contract(body)
     assert "created_at" in body
     assert "updated_at" in body
+    _assert_uuid(body["id"])
+    _assert_uuid(body["category_id"])
+    _assert_uuid(body["seller_id"])
+    _assert_uuid(body["images"][0]["id"])
+    _assert_uuid(body["characteristics"][0]["id"])
 
 
 def test_seller_id_taken_from_jwt(
@@ -57,9 +76,69 @@ def test_seller_id_taken_from_jwt(
     assert body["seller_id"] == jwt_seller_id
     assert body["seller_id"] != body_seller_id
 
-    product = db_session.get(Product, int(body["id"]))
+    product_id = UUID(body["id"])
+    product = db_session.get(Product, product_id)
     assert product is not None
-    assert product.seller_id == jwt_seller_id
+    assert product.seller_id == UUID(jwt_seller_id)
+
+
+def test_get_product_returns_product_and_nested_sku_contract_fields(
+    client,
+    db_session: Session,
+    category_factory,
+):
+    category = category_factory()
+    product = Product(
+        title="iPhone 15 Pro Max",
+        description="Flagship smartphone",
+        category_id=category.id,
+        seller_id=uuid4(),
+        status=ProductStatus.CREATED,
+    )
+    product.images = [ProductImage(url="/s3/iphone15-front.jpg", ordering=0)]
+    product.characteristics = [ProductCharacteristic(name="Brand", value="Apple")]
+    sku = SKU(
+        product=product,
+        name="256 GB Natural Titanium",
+        price=12999000,
+        active_quantity=5,
+    )
+    sku.image = "/s3/iphone15-sku.jpg"
+    sku.characteristics = [SKUCharacteristic(name="Storage", value="256 GB")]
+
+    db_session.add(product)
+    db_session.commit()
+
+    response = client.get(f"/api/v1/products/{product.id}")
+
+    assert response.status_code == 200
+    body = response.json()
+    _assert_product_response_contract(body)
+    _assert_uuid(body["id"])
+    _assert_uuid(body["category_id"])
+    _assert_uuid(body["seller_id"])
+
+    assert len(body["skus"]) == 1
+    sku_body = body["skus"][0]
+    _assert_uuid(sku_body["id"])
+    _assert_uuid(sku_body["product_id"])
+    assert sku_body["name"] == sku.name
+    assert sku_body["price"] == sku.price
+    assert sku_body["discount"] == 0
+    assert sku_body["cost_price"] == 0
+    assert sku_body["stock_quantity"] == 0
+    assert sku_body["active_quantity"] == sku.active_quantity
+    assert sku_body["reserved_quantity"] == 0
+    assert sku_body["article"] is None
+    assert "created_at" in sku_body
+    assert "updated_at" in sku_body
+    assert len(sku_body["images"]) == 1
+    _assert_uuid(sku_body["images"][0]["id"])
+    assert sku_body["images"][0]["id"] != str(sku.id)
+    assert sku_body["images"][0]["url"] == sku.image
+    assert sku_body["images"][0]["ordering"] == 0
+    assert sku_body["characteristics"][0]["name"] == "Storage"
+    _assert_uuid(sku_body["characteristics"][0]["id"])
 
 
 def test_missing_images_returns_400(
@@ -84,21 +163,49 @@ def test_missing_images_returns_400(
     assert response.json() == {"code": "INVALID_REQUEST", "message": "At least one image is required"}
 
 
-def test_missing_category_returns_422_with_field_details(client, category_factory, product_payload_factory, auth_headers):
+def test_missing_category_returns_422_validation_error(client, category_factory, product_payload_factory, auth_headers):
     category = category_factory()
     payload = product_payload_factory(category.id)
     payload.pop("category_id")
 
     response = client.post("/api/v1/products", json=payload, headers=auth_headers())
 
-    _assert_category_validation_detail(response)
-    assert response.json()["detail"][0]["type"] == "missing"
+    _assert_validation_error(response)
+    assert "category_id" in response.json()["message"]
 
 
-def test_invalid_category_id_returns_422_with_field_details(client, product_payload_factory, auth_headers):
-    payload = product_payload_factory(category_id=999999)
+def test_invalid_category_id_returns_422_validation_error(client, product_payload_factory, auth_headers):
+    payload = product_payload_factory(category_id="not-a-uuid")
 
     response = client.post("/api/v1/products", json=payload, headers=auth_headers())
 
-    _assert_category_validation_detail(response)
-    assert response.json()["detail"][0]["msg"] == "Category not found"
+    _assert_validation_error(response)
+    assert "category_id" in response.json()["message"]
+
+
+def test_nonexistent_category_id_returns_422_validation_error(client, product_payload_factory, auth_headers):
+    payload = product_payload_factory(category_id=uuid4())
+
+    response = client.post("/api/v1/products", json=payload, headers=auth_headers())
+
+    _assert_validation_error(response)
+    assert response.json()["message"] == "category_id: Category not found"
+
+
+def test_invalid_title_and_description_return_422_validation_error(
+    client,
+    category_factory,
+    product_payload_factory,
+    auth_headers,
+):
+    category = category_factory()
+
+    payload = product_payload_factory(category.id, title="")
+    response = client.post("/api/v1/products", json=payload, headers=auth_headers())
+    _assert_validation_error(response)
+    assert "title" in response.json()["message"]
+
+    payload = product_payload_factory(category.id, description="")
+    response = client.post("/api/v1/products", json=payload, headers=auth_headers())
+    _assert_validation_error(response)
+    assert "description" in response.json()["message"]

--- a/tests/api/test_products.py
+++ b/tests/api/test_products.py
@@ -1,0 +1,95 @@
+from sqlalchemy.orm import Session
+
+from src.models import Product
+
+
+def test_create_product_returns_201_with_created_status(client, category_factory, product_payload_factory, auth_headers):
+    category = category_factory()
+    payload = product_payload_factory(category.id)
+
+    response = client.post("/api/v1/products", json=payload, headers=auth_headers())
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["title"] == payload["title"]
+    assert body["description"] == payload["description"]
+    assert body["category_id"] == category.id
+    assert body["status"] == "CREATED"
+    assert body["skus"] == []
+    assert body["images"] == payload["images"]
+    assert body["seller_id"] == "c3d4e5f6-a7b8-9012-cdef-123456789012"
+    assert "created_at" in body
+    assert "updated_at" in body
+
+
+def test_seller_id_taken_from_jwt(
+    client,
+    db_session: Session,
+    category_factory,
+    product_payload_factory,
+    auth_headers,
+):
+    jwt_seller_id = "11111111-1111-1111-1111-111111111111"
+    body_seller_id = "22222222-2222-2222-2222-222222222222"
+    category = category_factory()
+    payload = product_payload_factory(category.id, seller_id=body_seller_id)
+
+    response = client.post("/api/v1/products", json=payload, headers=auth_headers(jwt_seller_id))
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["seller_id"] == jwt_seller_id
+    assert body["seller_id"] != body_seller_id
+
+    product = db_session.get(Product, body["id"])
+    assert product is not None
+    assert product.seller_id == jwt_seller_id
+
+
+def test_missing_images_returns_400(client, category_factory, product_payload_factory, auth_headers):
+    category = category_factory()
+    payload = product_payload_factory(category.id)
+    payload.pop("images")
+
+    response = client.post("/api/v1/products", json=payload, headers=auth_headers())
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "code": "INVALID_REQUEST",
+        "message": "At least one image is required",
+    }
+
+    payload = product_payload_factory(category.id, images=[])
+    response = client.post("/api/v1/products", json=payload, headers=auth_headers())
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "code": "INVALID_REQUEST",
+        "message": "At least one image is required",
+    }
+
+
+def test_missing_category_returns_400(client, category_factory, product_payload_factory, auth_headers):
+    category = category_factory()
+    payload = product_payload_factory(category.id)
+    payload.pop("category_id")
+
+    response = client.post("/api/v1/products", json=payload, headers=auth_headers())
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "code": "INVALID_REQUEST",
+        "message": "category_id is required",
+    }
+
+
+def test_invalid_category_id_returns_400(client, product_payload_factory, auth_headers):
+    payload = product_payload_factory(category_id=999999)
+
+    response = client.post("/api/v1/products", json=payload, headers=auth_headers())
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "code": "INVALID_REQUEST",
+        "message": "Category not found",
+    }

--- a/tests/api/test_products.py
+++ b/tests/api/test_products.py
@@ -3,6 +3,13 @@ from sqlalchemy.orm import Session
 from src.models import Product
 
 
+def _assert_category_validation_detail(response):
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert isinstance(detail, list)
+    assert detail[0]["loc"][-1] == "category_id"
+
+
 def test_create_product_returns_201_with_created_status(client, category_factory, product_payload_factory, auth_headers):
     category = category_factory()
     payload = product_payload_factory(category.id)
@@ -13,11 +20,15 @@ def test_create_product_returns_201_with_created_status(client, category_factory
     body = response.json()
     assert body["title"] == payload["title"]
     assert body["description"] == payload["description"]
-    assert body["category_id"] == category.id
+    assert body["category_id"] == str(category.id)
     assert body["status"] == "CREATED"
     assert body["skus"] == []
     assert body["images"] == payload["images"]
     assert body["seller_id"] == "c3d4e5f6-a7b8-9012-cdef-123456789012"
+    assert body["slug"] == f"iphone-15-pro-max-{body['id']}"
+    assert body["deleted"] is False
+    assert body["blocking_reason_id"] is None
+    assert body["moderator_comment"] is None
     assert "created_at" in body
     assert "updated_at" in body
 
@@ -32,7 +43,7 @@ def test_seller_id_taken_from_jwt(
     jwt_seller_id = "11111111-1111-1111-1111-111111111111"
     body_seller_id = "22222222-2222-2222-2222-222222222222"
     category = category_factory()
-    payload = product_payload_factory(category.id, seller_id=body_seller_id)
+    payload = product_payload_factory(category.id, seller_id=body_seller_id, sellerId=body_seller_id)
 
     response = client.post("/api/v1/products", json=payload, headers=auth_headers(jwt_seller_id))
 
@@ -41,55 +52,48 @@ def test_seller_id_taken_from_jwt(
     assert body["seller_id"] == jwt_seller_id
     assert body["seller_id"] != body_seller_id
 
-    product = db_session.get(Product, body["id"])
+    product = db_session.get(Product, int(body["id"]))
     assert product is not None
     assert product.seller_id == jwt_seller_id
 
 
-def test_missing_images_returns_400(client, category_factory, product_payload_factory, auth_headers):
+def test_create_product_without_images_returns_201_with_empty_images(
+    client,
+    category_factory,
+    product_payload_factory,
+    auth_headers,
+):
     category = category_factory()
     payload = product_payload_factory(category.id)
     payload.pop("images")
 
     response = client.post("/api/v1/products", json=payload, headers=auth_headers())
 
-    assert response.status_code == 400
-    assert response.json() == {
-        "code": "INVALID_REQUEST",
-        "message": "At least one image is required",
-    }
+    assert response.status_code == 201
+    assert response.json()["images"] == []
 
     payload = product_payload_factory(category.id, images=[])
     response = client.post("/api/v1/products", json=payload, headers=auth_headers())
 
-    assert response.status_code == 400
-    assert response.json() == {
-        "code": "INVALID_REQUEST",
-        "message": "At least one image is required",
-    }
+    assert response.status_code == 201
+    assert response.json()["images"] == []
 
 
-def test_missing_category_returns_400(client, category_factory, product_payload_factory, auth_headers):
+def test_missing_category_returns_422_with_field_details(client, category_factory, product_payload_factory, auth_headers):
     category = category_factory()
     payload = product_payload_factory(category.id)
     payload.pop("category_id")
 
     response = client.post("/api/v1/products", json=payload, headers=auth_headers())
 
-    assert response.status_code == 400
-    assert response.json() == {
-        "code": "INVALID_REQUEST",
-        "message": "category_id is required",
-    }
+    _assert_category_validation_detail(response)
+    assert response.json()["detail"][0]["type"] == "missing"
 
 
-def test_invalid_category_id_returns_400(client, product_payload_factory, auth_headers):
+def test_invalid_category_id_returns_422_with_field_details(client, product_payload_factory, auth_headers):
     payload = product_payload_factory(category_id=999999)
 
     response = client.post("/api/v1/products", json=payload, headers=auth_headers())
 
-    assert response.status_code == 400
-    assert response.json() == {
-        "code": "INVALID_REQUEST",
-        "message": "Category not found",
-    }
+    _assert_category_validation_detail(response)
+    assert response.json()["detail"][0]["msg"] == "Category not found"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,111 @@
+import base64
+import hashlib
+import hmac
+import json
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from src.core.config import settings
+from src.db.base import Base
+from src.db.session import get_db
+from src.main import app
+from src.models import Category
+
+
+@pytest.fixture()
+def db_session() -> Session:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, expire_on_commit=False)
+    Base.metadata.create_all(bind=engine)
+
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)
+        engine.dispose()
+
+
+@pytest.fixture()
+def client(db_session: Session) -> TestClient:
+    def override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app) as test_client:
+        yield test_client
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture()
+def category_factory(db_session: Session):
+    def create_category(name: str | None = None) -> Category:
+        category = Category(name=name or f"Category {uuid4()}")
+        db_session.add(category)
+        db_session.commit()
+        db_session.refresh(category)
+        return category
+
+    return create_category
+
+
+@pytest.fixture()
+def product_payload_factory():
+    def build_payload(category_id: int, **overrides):
+        payload = {
+            "title": "iPhone 15 Pro Max",
+            "description": "Flagship smartphone",
+            "category_id": category_id,
+            "images": [
+                {
+                    "url": "/s3/iphone15-front.jpg",
+                    "ordering": 0,
+                }
+            ],
+            "characteristics": [
+                {
+                    "name": "Brand",
+                    "value": "Apple",
+                }
+            ],
+        }
+        payload.update(overrides)
+        return payload
+
+    return build_payload
+
+
+def _b64encode(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def make_jwt(seller_id: str) -> str:
+    header = {"alg": settings.jwt_algorithm, "typ": "JWT"}
+    payload = {"seller_id": seller_id}
+    header_raw = _b64encode(json.dumps(header, separators=(",", ":")).encode("utf-8"))
+    payload_raw = _b64encode(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
+    signing_input = f"{header_raw}.{payload_raw}".encode("ascii")
+    signature = hmac.new(
+        settings.jwt_secret_key.encode("utf-8"),
+        signing_input,
+        hashlib.sha256,
+    ).digest()
+    return f"{header_raw}.{payload_raw}.{_b64encode(signature)}"
+
+
+@pytest.fixture()
+def auth_headers():
+    def build_headers(seller_id: str = "c3d4e5f6-a7b8-9012-cdef-123456789012") -> dict[str, str]:
+        return {"Authorization": f"Bearer {make_jwt(seller_id)}"}
+
+    return build_headers

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import base64
 import hashlib
 import hmac
 import json
+from uuid import UUID
 from uuid import uuid4
 
 import pytest
@@ -61,11 +62,11 @@ def category_factory(db_session: Session):
 
 @pytest.fixture()
 def product_payload_factory():
-    def build_payload(category_id: int, **overrides):
+    def build_payload(category_id: UUID | str, **overrides):
         payload = {
             "title": "iPhone 15 Pro Max",
             "description": "Flagship smartphone",
-            "category_id": category_id,
+            "category_id": str(category_id),
             "images": [
                 {
                     "url": "/s3/iphone15-front.jpg",


### PR DESCRIPTION
## US-B2B-01: создание продукта

Реализован `POST /api/v1/products` для B2B-создания продукта. Эндпоинт создает продукт со статусом `CREATED`, сохраняет `seller_id` только из claim `seller_id` в Bearer JWT, игнорирует любые `seller_id` или `sellerId` из тела запроса, возвращает `skus=[]` и не отправляет продукт без SKU на модерацию.

`images` обязательны по canon-flow B2B-1. Отсутствующее поле `images` и `images=[]` возвращают канонический `400 INVALID_REQUEST` с полевым описанием `At least one image is required`.

Контрактные идентификаторы продуктов теперь сохраняются как реальные UUID-backed значения, без stringification integer ID на границе ответа. Это покрывает `Category.id`, `Product.id`, `Product.category_id`, `Product.seller_id`, `ProductImage.id/product_id`, `ProductCharacteristic.id/product_id`, `SKU.id/product_id`, `SKUCharacteristic.id/sku_id` и ссылки invoice item на SKU. `ImageOut`, `CharacteristicOut` и вложенные SKU ids отдают UUID напрямую.

`ProductRead` и `ProductCreateRead` включают обязательные поля совместимости ответа: `slug`, `deleted`, `blocking_reason_id` и `moderator_comment`. Вложенные ответы SKU включают seller-view поля SKU, требуемые unified contract. Если экземпляр SKU-модели содержит одиночный URL `image` без отдельной таблицы изображений SKU, ответ формирует детерминированный UUID image id через `uuid5("sku-image:{sku_id}:0")`.

Валидация запроса теперь возвращает плоскую Error schema: `422 {"code":"VALIDATION_ERROR","message":"..."}`. Отсутствующий `category_id`, невалидный UUID-синтаксис `category_id`, валидный, но несуществующий `category_id`, а также невалидные `title`/`description` используют эту форму вместо стандартного FastAPI `detail` list. Пользовательские ошибки `400`, `401`, `404` и `409` используют единый формат `{code, message}`.

UUID-миграция рассчитана на свежее/текущее состояние проекта. Она переводит seeded categories на UUID и конвертирует контрактные product columns в UUID, но не пытается сделать полный data-preserving remap для уже заполненных PostgreSQL связей product/SKU/image/characteristic.

# Validation

Pytest proof commands:

```powershell
python -m pytest tests/api/test_products.py -vv
python -m pytest tests/api/test_products.py tests/api/test_skus.py -vv
```

В рамках обновления этого описания тесты и форматтеры не запускались; проверялся только diff `PR_DESCRIPTION.md`.

# Contract Notes

Контракт сверялся с merged B2B OpenAPI и `b2b/openapi.yaml`. Локальное зеркало финальной OpenAPI-спецификации в этом репозитории находится в `flow/openapi.yaml`.

`flow/neomarket-b2b.yaml` не рассматривается как актуальный authoritative source для US-B2B-01.

# ADR: хранение характеристик продукта

Для характеристик продукта сервис сохраняет существующую отдельную таблицу `product_characteristics`, а не переносит значения в JSON-поле на `products` и не вводит универсальную EAV-схему. JSON-поле проще расширять, но фильтрация по значениям характеристик становится database-specific и сложнее индексируется предсказуемо. EAV-схема гибкая, но усложняет типовые filtering joins и ослабляет ясность типов. Отдельная таблица `ProductCharacteristic` остается минимально подходящим решением для текущей модели: добавление новых характеристик требует только вставки новых строк, а фильтрация остается прямым join.