### PR TITLE
US-B2B-03: Implement product and SKU editing

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -103,6 +103,8 @@ US-B2B-03 does not add SKU `images[]` update support. Image-management endpoints
 
 Added `ProductStatus.BLOCKED` and migration `0004_add_blocked_product_status.py` using `ALTER TYPE product_status ADD VALUE IF NOT EXISTS 'BLOCKED'` inside Alembic `autocommit_block()`. Existing migrations were left unchanged.
 
+Arbiter contract fix: product edit responses now use the ProductResponse-required top-level fields `slug`, `deleted`, `blocking_reason_id`, and `moderator_comment`. Nested product SKUs now include SKUResponse-required fields including `product_id`, `discount`, `cost_price`, `stock_quantity`, `active_quantity`, `reserved_quantity`, `article`, `images`, `created_at`, and `updated_at`. Shared `ImageOut` and `CharacteristicOut` `id` fields are preserved for product images, product characteristics, SKU image response objects, and SKU characteristics.
+
 # US-B2B-03 Validation
 
 Pytest proof commands:
@@ -126,7 +128,7 @@ Required scenario results:
 Suite results:
 
 - Focused US-B2B-03 route migration scenarios: 4 passed
-- `tests/api/test_products.py tests/api/test_skus.py`: 21 passed
+- `tests/api/test_products.py tests/api/test_skus.py`: 22 passed
 
 Pytest completed without warnings in this run.
 

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -88,3 +88,59 @@ Options considered:
 - Fire-and-forget: lowest request latency, but it can leave a product in `ON_MODERATION` without a delivered event, making the first-SKU side effect hard to reason about.
 
 Decision: use synchronous POST for the first iteration. The outbox pattern is the preferred future reliability upgrade once background dispatch infrastructure is in scope.
+
+---
+
+# US-B2B-03 Summary
+
+Implemented authenticated edit behavior for `PUT /api/v1/products/{id}` and `PUT /api/v1/skus/{id}` on top of US-B2B-01 and US-B2B-02. This stacked PR depends on both US-B2B-01 and US-B2B-02 until they are merged into `dev`.
+
+Product edits ignore body `seller_id`, use the Bearer JWT `seller_id` claim for ownership, reject edits to another seller's product, and reject `HARD_BLOCKED` products without persisting changes or sending Moderation events. Edits to `MODERATED` and `BLOCKED` products return the product to `ON_MODERATION` and send a Moderation `EDITED` event.
+
+SKU edits ignore body `reserved_quantity`, `product_id`, and `seller_id` before validation, preserve persisted `reserved_quantity` and `product_id`, check ownership through the parent product, and reject SKUs whose parent product is `HARD_BLOCKED`. Edits to SKUs under `MODERATED` and `BLOCKED` parent products return the parent product to `ON_MODERATION` and send a Moderation `EDITED` event.
+
+Added `ProductStatus.BLOCKED` and migration `0004_add_blocked_product_status.py` using `ALTER TYPE product_status ADD VALUE IF NOT EXISTS 'BLOCKED'` inside Alembic `autocommit_block()`. Existing migrations were left unchanged.
+
+# US-B2B-03 Validation
+
+Pytest proof commands:
+
+```powershell
+python -m pytest tests/api/test_skus.py -vv -k "test_edit_moderated_product_returns_to_on_moderation or test_edit_blocked_product_returns_to_on_moderation or test_reserves_preserved_after_sku_edit or test_edit_hard_blocked_returns_403 or test_edit_others_product_returns_403"
+python -m pytest tests/api/test_products.py tests/api/test_skus.py -vv
+```
+
+Required scenario results:
+
+- `test_edit_moderated_product_returns_to_on_moderation`: passed
+- `test_edit_blocked_product_returns_to_on_moderation`: passed
+- `test_reserves_preserved_after_sku_edit`: passed
+- `test_edit_hard_blocked_returns_403`: passed
+- `test_edit_others_product_returns_403`: passed
+
+Suite results:
+
+- Required US-B2B-03 scenarios: 5 passed
+- `tests/api/test_products.py tests/api/test_skus.py`: 16 passed
+
+Pytest emitted the existing Windows cache warning while writing `.pytest_cache`; the test results passed.
+
+# ADR: Edited Moderation Event Idempotency
+
+Options considered:
+
+- Fresh UUID per edit attempt: preserves every accepted edit as a distinct Moderation event and avoids collapsing repeated edits into a single idempotent operation.
+- Deterministic key per product: simple and stable, but repeated edits to the same product could collapse into one Moderation event, which does not match the edit flow's need to re-enter moderation after each accepted edit.
+- Outbox-generated event identity: operationally stronger, but requires outbox infrastructure beyond this task.
+
+Decision: use a fresh UUID string for each `EDITED` event idempotency key. This is a local assumption because the canonical flow does not define deterministic idempotency semantics for repeated edits.
+
+# ADR: IDOR Ownership Enforcement
+
+Options considered:
+
+- Route/view ownership check: simple to read at the API boundary, but every new endpoint must remember to repeat the check before calling into write logic. Maintenance complexity stays low for one route, then grows as product and SKU endpoints multiply, and the risk of forgetting the check in a new endpoint is high.
+- DRF-style permission class: centralizes the concept and can reduce repetition in frameworks built around object permissions, but this service is FastAPI and does not currently have a permission-class layer. Adding one would increase maintenance complexity and introduce a new framework pattern for a small ownership rule.
+- Service/query-level ownership check: keeps ownership validation close to the data being modified and matches the existing product/SKU service structure. Maintenance complexity stays low because write paths already go through service functions, and the risk of forgetting the check in a new endpoint is lower when ownership is enforced in the mutation service rather than only in route code.
+
+Decision: enforce product and SKU ownership at the service/query level. This is the smallest fit for this FastAPI service, and product/SKU ownership is already checked close to the data being modified.

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -93,11 +93,13 @@ Decision: use synchronous POST for the first iteration. The outbox pattern is th
 
 # US-B2B-03 Summary
 
-Implemented authenticated edit behavior for `PUT /api/v1/products/{id}` and `PUT /api/v1/skus/{id}` on top of US-B2B-01 and US-B2B-02. This stacked PR depends on both US-B2B-01 and US-B2B-02 until they are merged into `dev`.
+Migrated authenticated edit behavior to the authoritative `flow/neomarket-b2b.yaml` contract: `PATCH /api/v1/products/{product_id}` and `PATCH /api/v1/skus/{sku_id}` are now the canonical US-B2B-03 edit endpoints. Existing `PUT /api/v1/products/{id}`, `PUT /api/v1/skus/{id}`, and legacy `PUT /api/v1/skus` remain supported for compatibility. This stacked PR depends on both US-B2B-01 and US-B2B-02 until they are merged into `dev`.
 
 Product edits ignore body `seller_id`, use the Bearer JWT `seller_id` claim for ownership, reject edits to another seller's product, and reject `HARD_BLOCKED` products without persisting changes or sending Moderation events. Edits to `MODERATED` and `BLOCKED` products return the product to `ON_MODERATION` and send a Moderation `EDITED` event.
 
-SKU edits ignore body `reserved_quantity`, `product_id`, and `seller_id` before validation, preserve persisted `reserved_quantity` and `product_id`, check ownership through the parent product, and reject SKUs whose parent product is `HARD_BLOCKED`. Edits to SKUs under `MODERATED` and `BLOCKED` parent products return the parent product to `ON_MODERATION` and send a Moderation `EDITED` event.
+SKU edits ignore body `reserved_quantity`, `reservedQuantity`, `product_id`, `productId`, `seller_id`, and `sellerId` before validation, preserve persisted `reserved_quantity` and `product_id`, check ownership through the parent product, and reject SKUs whose parent product is `HARD_BLOCKED`. Edits to SKUs under `MODERATED` and `BLOCKED` parent products return the parent product to `ON_MODERATION` and send a Moderation `EDITED` event. SKU `article` can now be updated through the canonical PATCH route and legacy PUT routes.
+
+US-B2B-03 does not add SKU `images[]` update support. Image-management endpoints are separate in the authoritative flow, so this migration keeps edit behavior scoped to existing SKU fields plus `article`.
 
 Added `ProductStatus.BLOCKED` and migration `0004_add_blocked_product_status.py` using `ALTER TYPE product_status ADD VALUE IF NOT EXISTS 'BLOCKED'` inside Alembic `autocommit_block()`. Existing migrations were left unchanged.
 
@@ -106,24 +108,27 @@ Added `ProductStatus.BLOCKED` and migration `0004_add_blocked_product_status.py`
 Pytest proof commands:
 
 ```powershell
-python -m pytest tests/api/test_skus.py -vv -k "test_edit_moderated_product_returns_to_on_moderation or test_edit_blocked_product_returns_to_on_moderation or test_reserves_preserved_after_sku_edit or test_edit_hard_blocked_returns_403 or test_edit_others_product_returns_403"
+python -m pytest tests/api/test_products.py tests/api/test_skus.py -vv -k "test_patch_product_alias_returns_to_on_moderation or test_patch_sku_alias_updates_sku or test_legacy_put_product_edit_route_remains_supported or test_legacy_put_sku_edit_route_remains_supported"
 python -m pytest tests/api/test_products.py tests/api/test_skus.py -vv
 ```
 
 Required scenario results:
 
-- `test_edit_moderated_product_returns_to_on_moderation`: passed
-- `test_edit_blocked_product_returns_to_on_moderation`: passed
-- `test_reserves_preserved_after_sku_edit`: passed
-- `test_edit_hard_blocked_returns_403`: passed
-- `test_edit_others_product_returns_403`: passed
+- `test_patch_product_alias_returns_to_on_moderation`: passed
+- `test_patch_sku_alias_updates_sku`: passed
+- `test_legacy_put_product_edit_route_remains_supported`: passed
+- `test_legacy_put_sku_edit_route_remains_supported`: passed
+- `test_patch_moderated_product_returns_to_on_moderation`: passed
+- `test_patch_blocked_product_returns_to_on_moderation`: passed
+- `test_patch_hard_blocked_returns_403`: passed
+- `test_patch_others_product_returns_403`: passed
 
 Suite results:
 
-- Required US-B2B-03 scenarios: 5 passed
-- `tests/api/test_products.py tests/api/test_skus.py`: 16 passed
+- Focused US-B2B-03 route migration scenarios: 4 passed
+- `tests/api/test_products.py tests/api/test_skus.py`: 21 passed
 
-Pytest emitted the existing Windows cache warning while writing `.pytest_cache`; the test results passed.
+Pytest completed without warnings in this run.
 
 # ADR: Edited Moderation Event Idempotency
 
@@ -144,3 +149,13 @@ Options considered:
 - Service/query-level ownership check: keeps ownership validation close to the data being modified and matches the existing product/SKU service structure. Maintenance complexity stays low because write paths already go through service functions, and the risk of forgetting the check in a new endpoint is lower when ownership is enforced in the mutation service rather than only in route code.
 
 Decision: enforce product and SKU ownership at the service/query level. This is the smallest fit for this FastAPI service, and product/SKU ownership is already checked close to the data being modified.
+
+# ADR: US-B2B-03 Edit Route Migration Scope
+
+Options considered:
+
+- Replace PUT with PATCH only: matches the authoritative flow exactly, but would break clients already using the previous US-B2B-03 implementation.
+- Keep PUT as canonical: lowest code churn, but keeps the implementation out of sync with `flow/neomarket-b2b.yaml`.
+- Add PATCH as canonical and keep PUT as compatibility: aligns new clients with the authoritative flow while avoiding an unnecessary breaking change.
+
+Decision: add canonical `PATCH /api/v1/products/{product_id}` and `PATCH /api/v1/skus/{sku_id}` routes that reuse the existing edit services, while keeping the PUT routes as compatibility aliases. SKU `article` is included in update because it is an existing stored SKU field and part of the create/read contract. SKU `images[]` update remains out of scope because image-management endpoints are modeled separately.

--- a/migrations/versions/0004_add_blocked_product_status.py
+++ b/migrations/versions/0004_add_blocked_product_status.py
@@ -1,0 +1,20 @@
+"""Add blocked product status."""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "0004_add_blocked_product_status"
+down_revision = "0003_add_sku_moderation_fields"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("ALTER TYPE product_status ADD VALUE IF NOT EXISTS 'BLOCKED'")
+
+
+def downgrade() -> None:
+    pass

--- a/src/api/routes/products.py
+++ b/src/api/routes/products.py
@@ -8,7 +8,10 @@ from src.api.deps import CurrentSeller, get_current_seller
 from src.db.session import get_db
 from src.schemas.product import ProductCreate, ProductCreateRead, ProductRead, ProductUpdate
 from src.services.product_service import (
+    ModerationUnavailableError,
     ProductCreateValidationError,
+    ProductForbiddenError,
+    ProductOwnerError,
     create_product,
     get_product_by_id,
     update_product,
@@ -29,6 +32,10 @@ def _invalid_request(message: str) -> JSONResponse:
         status_code=400,
         content={"code": "INVALID_REQUEST", "message": message},
     )
+
+
+def _error(status_code: int, code: str, message: str) -> JSONResponse:
+    return JSONResponse(status_code=status_code, content={"code": code, "message": message})
 
 
 @router.post("", response_model=ProductCreateRead, status_code=status.HTTP_201_CREATED)
@@ -57,6 +64,17 @@ def get_product_endpoint(id: uuid.UUID, db: Session = Depends(get_db)) -> Produc
 def update_product_endpoint(
     id: uuid.UUID,
     payload: ProductUpdate,
+    current_seller: CurrentSeller | JSONResponse = Depends(get_current_seller),
     db: Session = Depends(get_db),
-) -> ProductRead:
-    return update_product(db, id, payload)
+) -> ProductRead | JSONResponse:
+    if isinstance(current_seller, JSONResponse):
+        return current_seller
+
+    try:
+        return update_product(db, id, payload, current_seller.seller_id)
+    except ProductOwnerError as exc:
+        return _error(403, "NOT_OWNER", str(exc))
+    except ProductForbiddenError as exc:
+        return _error(403, "FORBIDDEN", str(exc))
+    except ModerationUnavailableError:
+        return _error(502, "MODERATION_UNAVAILABLE", "Moderation service unavailable")

--- a/src/api/routes/products.py
+++ b/src/api/routes/products.py
@@ -78,3 +78,23 @@ def update_product_endpoint(
         return _error(403, "FORBIDDEN", str(exc))
     except ModerationUnavailableError:
         return _error(502, "MODERATION_UNAVAILABLE", "Moderation service unavailable")
+
+
+@router.patch("/{product_id}", response_model=ProductRead, status_code=status.HTTP_200_OK)
+def patch_product_endpoint(
+    product_id: int,
+    payload: ProductUpdate,
+    current_seller: CurrentSeller | JSONResponse = Depends(get_current_seller),
+    db: Session = Depends(get_db),
+) -> ProductRead | JSONResponse:
+    if isinstance(current_seller, JSONResponse):
+        return current_seller
+
+    try:
+        return update_product(db, product_id, payload, current_seller.seller_id)
+    except ProductOwnerError as exc:
+        return _error(403, "NOT_OWNER", str(exc))
+    except ProductForbiddenError as exc:
+        return _error(403, "FORBIDDEN", str(exc))
+    except ModerationUnavailableError:
+        return _error(502, "MODERATION_UNAVAILABLE", "Moderation service unavailable")

--- a/src/api/routes/products.py
+++ b/src/api/routes/products.py
@@ -82,7 +82,7 @@ def update_product_endpoint(
 
 @router.patch("/{product_id}", response_model=ProductResponse, status_code=status.HTTP_200_OK)
 def patch_product_endpoint(
-    product_id: int,
+    product_id: uuid.UUID,
     payload: ProductUpdate,
     current_seller: CurrentSeller | JSONResponse = Depends(get_current_seller),
     db: Session = Depends(get_db),

--- a/src/api/routes/products.py
+++ b/src/api/routes/products.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 
 from src.api.deps import CurrentSeller, get_current_seller
 from src.db.session import get_db
-from src.schemas.product import ProductCreate, ProductCreateRead, ProductRead, ProductUpdate
+from src.schemas.product import ProductCreate, ProductCreateRead, ProductRead, ProductResponse, ProductUpdate
 from src.services.product_service import (
     ModerationUnavailableError,
     ProductCreateValidationError,
@@ -60,13 +60,13 @@ def get_product_endpoint(id: uuid.UUID, db: Session = Depends(get_db)) -> Produc
     return get_product_by_id(db, id)
 
 
-@router.put("/{id}", response_model=ProductRead, status_code=status.HTTP_200_OK)
+@router.put("/{id}", response_model=ProductResponse, status_code=status.HTTP_200_OK)
 def update_product_endpoint(
     id: uuid.UUID,
     payload: ProductUpdate,
     current_seller: CurrentSeller | JSONResponse = Depends(get_current_seller),
     db: Session = Depends(get_db),
-) -> ProductRead | JSONResponse:
+) -> ProductResponse | JSONResponse:
     if isinstance(current_seller, JSONResponse):
         return current_seller
 
@@ -80,13 +80,13 @@ def update_product_endpoint(
         return _error(502, "MODERATION_UNAVAILABLE", "Moderation service unavailable")
 
 
-@router.patch("/{product_id}", response_model=ProductRead, status_code=status.HTTP_200_OK)
+@router.patch("/{product_id}", response_model=ProductResponse, status_code=status.HTTP_200_OK)
 def patch_product_endpoint(
     product_id: int,
     payload: ProductUpdate,
     current_seller: CurrentSeller | JSONResponse = Depends(get_current_seller),
     db: Session = Depends(get_db),
-) -> ProductRead | JSONResponse:
+) -> ProductResponse | JSONResponse:
     if isinstance(current_seller, JSONResponse):
         return current_seller
 

--- a/src/api/routes/skus.py
+++ b/src/api/routes/skus.py
@@ -1,3 +1,5 @@
+import uuid
+
 from fastapi import APIRouter, Depends, Request, status
 from fastapi.responses import JSONResponse
 from pydantic import ValidationError as PydanticValidationError
@@ -63,7 +65,7 @@ async def _parse_sku_create_payload(request: Request) -> SKUCreate | JSONRespons
         return _invalid_request(_sku_validation_message(exc))
 
 
-async def _parse_sku_update_payload(request: Request, sku_id: int | None = None) -> SKUUpdate | JSONResponse:
+async def _parse_sku_update_payload(request: Request, sku_id: uuid.UUID | None = None) -> SKUUpdate | JSONResponse:
     try:
         body = await request.json()
     except ValueError:
@@ -116,7 +118,7 @@ async def create_sku_endpoint(
 
 @router.put("/{id}", response_model=SKURead, status_code=status.HTTP_200_OK)
 async def update_sku_by_id_endpoint(
-    id: int,
+    id: uuid.UUID,
     request: Request,
     current_seller: CurrentSeller | JSONResponse = Depends(get_current_seller),
     db: Session = Depends(get_db),
@@ -140,7 +142,7 @@ async def update_sku_by_id_endpoint(
 
 @router.patch("/{sku_id}", response_model=SKURead, status_code=status.HTTP_200_OK)
 async def patch_sku_endpoint(
-    sku_id: int,
+    sku_id: uuid.UUID,
     request: Request,
     current_seller: CurrentSeller | JSONResponse = Depends(get_current_seller),
     db: Session = Depends(get_db),

--- a/src/api/routes/skus.py
+++ b/src/api/routes/skus.py
@@ -63,6 +63,32 @@ async def _parse_sku_create_payload(request: Request) -> SKUCreate | JSONRespons
         return _invalid_request(_sku_validation_message(exc))
 
 
+async def _parse_sku_update_payload(request: Request, sku_id: int | None = None) -> SKUUpdate | JSONResponse:
+    try:
+        body = await request.json()
+    except ValueError:
+        return _invalid_request("Invalid JSON body")
+
+    if not isinstance(body, dict):
+        return _invalid_request("Invalid SKU payload")
+
+    payload_data = dict(body)
+    payload_data.pop("seller_id", None)
+    payload_data.pop("sellerId", None)
+    payload_data.pop("product_id", None)
+    payload_data.pop("productId", None)
+    payload_data.pop("reserved_quantity", None)
+    payload_data.pop("reservedQuantity", None)
+
+    if sku_id is not None:
+        payload_data["id"] = sku_id
+
+    try:
+        return SKUUpdate.model_validate(payload_data)
+    except PydanticValidationError as exc:
+        return _invalid_request(_sku_validation_message(exc))
+
+
 @router.post("", response_model=SKURead, status_code=status.HTTP_201_CREATED)
 async def create_sku_endpoint(
     request: Request,
@@ -88,7 +114,49 @@ async def create_sku_endpoint(
         return _error(502, "MODERATION_UNAVAILABLE", "Moderation service unavailable")
 
 
+@router.put("/{id}", response_model=SKURead, status_code=status.HTTP_200_OK)
+async def update_sku_by_id_endpoint(
+    id: int,
+    request: Request,
+    current_seller: CurrentSeller | JSONResponse = Depends(get_current_seller),
+    db: Session = Depends(get_db),
+) -> SKURead | JSONResponse:
+    if isinstance(current_seller, JSONResponse):
+        return current_seller
+
+    payload = await _parse_sku_update_payload(request, id)
+    if isinstance(payload, JSONResponse):
+        return payload
+
+    try:
+        return update_sku(db, id, payload, current_seller.seller_id)
+    except SKUOwnerError as exc:
+        return _error(403, "NOT_OWNER", str(exc))
+    except SKUForbiddenError as exc:
+        return _error(403, "FORBIDDEN", str(exc))
+    except ModerationUnavailableError:
+        return _error(502, "MODERATION_UNAVAILABLE", "Moderation service unavailable")
+
+
 @router.put("", response_model=SKURead, status_code=status.HTTP_200_OK)
-def update_sku_endpoint(payload: SKUUpdate, db: Session = Depends(get_db)) -> SKURead:
-    return update_sku(db, payload)
+async def update_sku_endpoint(
+    request: Request,
+    current_seller: CurrentSeller | JSONResponse = Depends(get_current_seller),
+    db: Session = Depends(get_db),
+) -> SKURead | JSONResponse:
+    if isinstance(current_seller, JSONResponse):
+        return current_seller
+
+    payload = await _parse_sku_update_payload(request)
+    if isinstance(payload, JSONResponse):
+        return payload
+
+    try:
+        return update_sku(db, payload.id, payload, current_seller.seller_id)
+    except SKUOwnerError as exc:
+        return _error(403, "NOT_OWNER", str(exc))
+    except SKUForbiddenError as exc:
+        return _error(403, "FORBIDDEN", str(exc))
+    except ModerationUnavailableError:
+        return _error(502, "MODERATION_UNAVAILABLE", "Moderation service unavailable")
 

--- a/src/api/routes/skus.py
+++ b/src/api/routes/skus.py
@@ -138,6 +138,30 @@ async def update_sku_by_id_endpoint(
         return _error(502, "MODERATION_UNAVAILABLE", "Moderation service unavailable")
 
 
+@router.patch("/{sku_id}", response_model=SKURead, status_code=status.HTTP_200_OK)
+async def patch_sku_endpoint(
+    sku_id: int,
+    request: Request,
+    current_seller: CurrentSeller | JSONResponse = Depends(get_current_seller),
+    db: Session = Depends(get_db),
+) -> SKURead | JSONResponse:
+    if isinstance(current_seller, JSONResponse):
+        return current_seller
+
+    payload = await _parse_sku_update_payload(request, sku_id)
+    if isinstance(payload, JSONResponse):
+        return payload
+
+    try:
+        return update_sku(db, sku_id, payload, current_seller.seller_id)
+    except SKUOwnerError as exc:
+        return _error(403, "NOT_OWNER", str(exc))
+    except SKUForbiddenError as exc:
+        return _error(403, "FORBIDDEN", str(exc))
+    except ModerationUnavailableError:
+        return _error(502, "MODERATION_UNAVAILABLE", "Moderation service unavailable")
+
+
 @router.put("", response_model=SKURead, status_code=status.HTTP_200_OK)
 async def update_sku_endpoint(
     request: Request,

--- a/src/models/product.py
+++ b/src/models/product.py
@@ -14,6 +14,7 @@ class ProductStatus(str, Enum):
     DRAFT = "DRAFT"
     ON_MODERATION = "ON_MODERATION"
     MODERATED = "MODERATED"
+    BLOCKED = "BLOCKED"
     REJECTED = "REJECTED"
     HARD_BLOCKED = "HARD_BLOCKED"
 

--- a/src/schemas/product.py
+++ b/src/schemas/product.py
@@ -88,13 +88,9 @@ class ProductSKURead(APIModel):
         }
 
 
-class ProductSKUImageOut(ImageOut):
-    id: str
-
-
 class ProductSKUResponse(APIModel):
-    id: int
-    product_id: int
+    id: uuid.UUID
+    product_id: uuid.UUID
     name: str
     price: int
     discount: int
@@ -114,20 +110,16 @@ class ProductSKUResponse(APIModel):
 
     @computed_field
     @property
-    def images(self) -> list[ProductSKUImageOut]:
+    def images(self) -> list[ImageOut]:
         if not self.image:
             return []
         return [
-            ProductSKUImageOut(
-                id=f"sku-image:{self.id}:0",
+            ImageOut(
+                id=uuid.uuid5(SKU_IMAGE_NAMESPACE, f"sku-image:{self.id}:0"),
                 url=self.image,
                 ordering=0,
             )
         ]
-
-    @field_serializer("id", "product_id")
-    def serialize_id(self, value: int) -> str:
-        return str(value)
 
 
 class ProductRead(APIModel):

--- a/src/schemas/product.py
+++ b/src/schemas/product.py
@@ -88,6 +88,48 @@ class ProductSKURead(APIModel):
         }
 
 
+class ProductSKUImageOut(ImageOut):
+    id: str
+
+
+class ProductSKUResponse(APIModel):
+    id: int
+    product_id: int
+    name: str
+    price: int
+    discount: int
+    cost_price: int | None
+    active_quantity: int
+    reserved_quantity: int
+    article: str | None = None
+    image: str = Field(default="", exclude=True)
+    characteristics: list[CharacteristicOut] = Field(default_factory=list)
+    created_at: datetime
+    updated_at: datetime
+
+    @computed_field
+    @property
+    def stock_quantity(self) -> int:
+        return self.active_quantity + self.reserved_quantity
+
+    @computed_field
+    @property
+    def images(self) -> list[ProductSKUImageOut]:
+        if not self.image:
+            return []
+        return [
+            ProductSKUImageOut(
+                id=f"sku-image:{self.id}:0",
+                url=self.image,
+                ordering=0,
+            )
+        ]
+
+    @field_serializer("id", "product_id")
+    def serialize_id(self, value: int) -> str:
+        return str(value)
+
+
 class ProductRead(APIModel):
     id: uuid.UUID
     seller_id: uuid.UUID
@@ -114,4 +156,8 @@ class ProductRead(APIModel):
 
 class ProductCreateRead(ProductRead):
     pass
+
+
+class ProductResponse(ProductCreateRead):
+    skus: list[ProductSKUResponse] = Field(default_factory=list)
 

--- a/src/schemas/sku.py
+++ b/src/schemas/sku.py
@@ -32,6 +32,7 @@ class SKUUpdate(APIModel):
     price: int | None = Field(default=None, ge=0)
     cost_price: int | None = Field(default=None, ge=0)
     discount: int | None = Field(default=None, ge=0)
+    article: str | None = Field(default=None, max_length=255)
     image: str | None = None
     active_quantity: int | None = Field(
         default=None,

--- a/src/services/moderation_service.py
+++ b/src/services/moderation_service.py
@@ -1,5 +1,5 @@
 from datetime import UTC, datetime
-from uuid import NAMESPACE_URL, uuid5
+from uuid import NAMESPACE_URL, uuid4, uuid5
 
 import httpx
 
@@ -20,10 +20,19 @@ def build_product_created_event(product_id: int, seller_id: str) -> dict[str, st
     }
 
 
-def send_product_created_event(product_id: int, seller_id: str) -> None:
+def build_product_edited_event(product_id: int, seller_id: str) -> dict[str, str | int]:
+    return {
+        "idempotency_key": str(uuid4()),
+        "product_id": product_id,
+        "seller_id": seller_id,
+        "event": "EDITED",
+        "date": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+    }
+
+
+def _send_product_event(payload: dict[str, str | int]) -> None:
     url = f"{settings.moderation_url.rstrip('/')}/api/v1/events/product"
     headers = {"X-Service-Key": settings.b2b_to_mod_key}
-    payload = build_product_created_event(product_id, seller_id)
 
     try:
         response = httpx.post(
@@ -35,3 +44,11 @@ def send_product_created_event(product_id: int, seller_id: str) -> None:
         response.raise_for_status()
     except httpx.HTTPError as exc:
         raise ModerationSenderError("Moderation service unavailable") from exc
+
+
+def send_product_created_event(product_id: int, seller_id: str) -> None:
+    _send_product_event(build_product_created_event(product_id, seller_id))
+
+
+def send_product_edited_event(product_id: int, seller_id: str) -> None:
+    _send_product_event(build_product_edited_event(product_id, seller_id))

--- a/src/services/product_service.py
+++ b/src/services/product_service.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Session, selectinload
 from src.models import Category, Product, ProductCharacteristic, ProductImage, ProductStatus, SKU
 from src.schemas.product import ProductCreate, ProductUpdate
 from src.services.errors import NotFoundError
+from src.services.moderation_service import send_product_edited_event
 
 
 class ProductCreateValidationError(Exception):
@@ -13,6 +14,18 @@ class ProductCreateValidationError(Exception):
         self.field = field
         self.message = message
         super().__init__(message)
+
+
+class ProductForbiddenError(Exception):
+    pass
+
+
+class ProductOwnerError(Exception):
+    pass
+
+
+class ModerationUnavailableError(Exception):
+    pass
 
 
 def _product_query():
@@ -65,9 +78,7 @@ def create_product(db: Session, payload: ProductCreate, seller_id: uuid.UUID) ->
     return get_product_by_id(db, product.id)
 
 
-def update_product(db: Session, product_id: uuid.UUID, payload: ProductUpdate) -> Product:
-    product = get_product_by_id(db, product_id)
-
+def _apply_product_updates(db: Session, product: Product, payload: ProductUpdate) -> None:
     if payload.title is not None:
         product.title = payload.title
     if payload.description is not None:
@@ -81,6 +92,32 @@ def update_product(db: Session, product_id: uuid.UUID, payload: ProductUpdate) -
         product.characteristics = [
             ProductCharacteristic(name=item.name, value=item.value) for item in payload.characteristics
         ]
+
+
+def update_product(db: Session, product_id: uuid.UUID, payload: ProductUpdate, seller_id: uuid.UUID) -> Product:
+    product = get_product_by_id(db, product_id)
+
+    if product.seller_id != seller_id:
+        raise ProductOwnerError("Product does not belong to the authenticated seller")
+    if product.status == ProductStatus.HARD_BLOCKED:
+        raise ProductForbiddenError("Cannot edit hard-blocked product")
+
+    should_send_moderation_event = product.status in {
+        ProductStatus.MODERATED,
+        ProductStatus.BLOCKED,
+    }
+
+    _apply_product_updates(db, product, payload)
+    if should_send_moderation_event:
+        product.status = ProductStatus.ON_MODERATION
+
+    db.flush()
+    if should_send_moderation_event:
+        try:
+            send_product_edited_event(product_id=str(product.id), seller_id=str(seller_id))
+        except Exception as exc:
+            db.rollback()
+            raise ModerationUnavailableError("Moderation service unavailable") from exc
 
     db.commit()
     return get_product_by_id(db, product_id)

--- a/src/services/sku_service.py
+++ b/src/services/sku_service.py
@@ -99,6 +99,8 @@ def _apply_sku_updates(sku: SKU, payload: SKUUpdate) -> None:
         sku.cost_price = payload.cost_price
     if payload.discount is not None:
         sku.discount = payload.discount
+    if payload.article is not None:
+        sku.article = payload.article
     if payload.image is not None:
         sku.image = payload.image
     if payload.active_quantity is not None:

--- a/src/services/sku_service.py
+++ b/src/services/sku_service.py
@@ -109,7 +109,7 @@ def _apply_sku_updates(sku: SKU, payload: SKUUpdate) -> None:
         sku.characteristics = [SKUCharacteristic(name=item.name, value=item.value) for item in payload.characteristics]
 
 
-def update_sku(db: Session, sku_id: int, payload: SKUUpdate, seller_id: str) -> SKU:
+def update_sku(db: Session, sku_id: uuid.UUID, payload: SKUUpdate, seller_id: uuid.UUID) -> SKU:
     sku = _get_sku_or_raise(db, sku_id)
     product = sku.product
 
@@ -130,7 +130,7 @@ def update_sku(db: Session, sku_id: int, payload: SKUUpdate, seller_id: str) -> 
     db.flush()
     if should_send_moderation_event:
         try:
-            send_product_edited_event(product_id=product.id, seller_id=seller_id)
+            send_product_edited_event(product_id=str(product.id), seller_id=str(seller_id))
         except Exception as exc:
             db.rollback()
             raise ModerationUnavailableError("Moderation service unavailable") from exc

--- a/src/services/sku_service.py
+++ b/src/services/sku_service.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import Session, selectinload
 
 from src.models import Product, ProductStatus, SKU, SKUCharacteristic
 from src.schemas.sku import SKUCreate, SKUUpdate
-from src.services.moderation_service import send_product_created_event
+from src.services.moderation_service import send_product_created_event, send_product_edited_event
 from src.services.errors import NotFoundError
 
 
@@ -22,7 +22,7 @@ class ModerationUnavailableError(Exception):
 
 
 def _sku_query():
-    return select(SKU).options(selectinload(SKU.characteristics))
+    return select(SKU).options(selectinload(SKU.characteristics), selectinload(SKU.product))
 
 
 def _get_product_or_raise(db: Session, product_id: uuid.UUID) -> Product:
@@ -90,9 +90,7 @@ def create_sku(db: Session, payload: SKUCreate, seller_id: uuid.UUID) -> SKU:
     return _get_sku_or_raise(db, sku.id)
 
 
-def update_sku(db: Session, payload: SKUUpdate) -> SKU:
-    sku = _get_sku_or_raise(db, payload.id)
-
+def _apply_sku_updates(sku: SKU, payload: SKUUpdate) -> None:
     if payload.name is not None:
         sku.name = payload.name
     if payload.price is not None:
@@ -107,6 +105,33 @@ def update_sku(db: Session, payload: SKUUpdate) -> SKU:
         sku.active_quantity = payload.active_quantity
     if payload.characteristics is not None:
         sku.characteristics = [SKUCharacteristic(name=item.name, value=item.value) for item in payload.characteristics]
+
+
+def update_sku(db: Session, sku_id: int, payload: SKUUpdate, seller_id: str) -> SKU:
+    sku = _get_sku_or_raise(db, sku_id)
+    product = sku.product
+
+    if product.seller_id != seller_id:
+        raise SKUOwnerError("Product does not belong to the authenticated seller")
+    if product.status == ProductStatus.HARD_BLOCKED:
+        raise SKUForbiddenError("Cannot edit SKU for hard-blocked product")
+
+    should_send_moderation_event = product.status in {
+        ProductStatus.MODERATED,
+        ProductStatus.BLOCKED,
+    }
+
+    _apply_sku_updates(sku, payload)
+    if should_send_moderation_event:
+        product.status = ProductStatus.ON_MODERATION
+
+    db.flush()
+    if should_send_moderation_event:
+        try:
+            send_product_edited_event(product_id=product.id, seller_id=seller_id)
+        except Exception as exc:
+            db.rollback()
+            raise ModerationUnavailableError("Moderation service unavailable") from exc
 
     db.commit()
     return _get_sku_or_raise(db, sku.id)

--- a/tests/api/test_products.py
+++ b/tests/api/test_products.py
@@ -49,6 +49,7 @@ def product_factory(db_session: Session, category_factory):
             status=status,
         )
         product.images = [ProductImage(url="/s3/iphone15-front.jpg", ordering=0)]
+        product.characteristics = [ProductCharacteristic(name="Brand", value="Apple")]
         db_session.add(product)
         db_session.commit()
         db_session.refresh(product)
@@ -76,6 +77,25 @@ def _assert_product_response_contract(body: dict) -> None:
     assert body["deleted"] is False
     assert body["blocking_reason_id"] is None
     assert body["moderator_comment"] is None
+
+
+def create_existing_sku(db_session: Session, product: Product, *, image: str = "/s3/iphone15-black-128.jpg") -> SKU:
+    sku = SKU(
+        product_id=product.id,
+        name="128GB Black",
+        price=9999000,
+        cost_price=7000000,
+        discount=10,
+        article="IPHONE15-BLACK-128",
+        image=image,
+        active_quantity=4,
+        reserved_quantity=3,
+    )
+    sku.characteristics = [SKUCharacteristic(name="Color", value="Black")]
+    db_session.add(sku)
+    db_session.commit()
+    db_session.refresh(sku)
+    return sku
 
 
 def test_create_product_returns_201_with_created_status(client, category_factory, product_payload_factory, auth_headers):
@@ -283,6 +303,12 @@ def test_patch_product_alias_returns_to_on_moderation(
     assert body["title"] == "iPhone 15 Pro Max Updated"
     assert body["seller_id"] == SELLER_ID
     assert body["status"] == "ON_MODERATION"
+    assert body["slug"] == f"iphone-15-pro-max-updated-{product.id}"
+    assert body["deleted"] is False
+    assert body["blocking_reason_id"] is None
+    assert body["moderator_comment"] is None
+    assert body["images"][0]["id"]
+    assert body["characteristics"][0]["id"]
 
     db_session.refresh(product)
     assert product.status == ProductStatus.ON_MODERATION
@@ -313,8 +339,53 @@ def test_legacy_put_product_edit_route_remains_supported(
     body = response.json()
     assert body["description"] == "Updated description"
     assert body["status"] == "ON_MODERATION"
+    assert body["slug"] == f"iphone-15-pro-max-{product.id}"
+    assert body["deleted"] is False
+    assert body["blocking_reason_id"] is None
+    assert body["moderator_comment"] is None
 
     db_session.refresh(product)
     assert product.status == ProductStatus.ON_MODERATION
     assert len(moderation_requests) == 1
     assert moderation_requests[0]["json"]["event"] == "EDITED"
+
+
+def test_patch_product_response_includes_nested_sku_contract_fields(
+    client,
+    db_session: Session,
+    product_factory,
+    auth_headers,
+    moderation_requests,
+):
+    product = product_factory(status=ProductStatus.CREATED)
+    sku = create_existing_sku(db_session, product)
+
+    response = client.patch(
+        f"/api/v1/products/{product.id}",
+        json={"title": "iPhone 15 Pro Max Updated"},
+        headers=auth_headers(SELLER_ID),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["skus"]
+    response_sku = body["skus"][0]
+    assert response_sku["id"] == str(sku.id)
+    assert response_sku["product_id"] == str(product.id)
+    assert response_sku["name"] == "128GB Black"
+    assert response_sku["price"] == 9999000
+    assert response_sku["discount"] == 10
+    assert response_sku["cost_price"] == 7000000
+    assert response_sku["stock_quantity"] == 7
+    assert response_sku["active_quantity"] == 4
+    assert response_sku["reserved_quantity"] == 3
+    assert response_sku["article"] == "IPHONE15-BLACK-128"
+    assert response_sku["images"][0]["id"] == f"sku-image:{sku.id}:0"
+    assert response_sku["images"][0]["url"] == "/s3/iphone15-black-128.jpg"
+    assert response_sku["images"][0]["ordering"] == 0
+    assert response_sku["created_at"]
+    assert response_sku["updated_at"]
+    assert response_sku["characteristics"][0]["id"]
+    assert response_sku["characteristics"][0]["name"] == "Color"
+    assert response_sku["characteristics"][0]["value"] == "Black"
+    assert moderation_requests == []

--- a/tests/api/test_products.py
+++ b/tests/api/test_products.py
@@ -1,8 +1,60 @@
 from uuid import UUID, uuid4
 
+import pytest
 from sqlalchemy.orm import Session
 
 from src.models import Product, ProductCharacteristic, ProductImage, ProductStatus, SKU, SKUCharacteristic
+
+
+SELLER_ID = "c3d4e5f6-a7b8-9012-cdef-123456789012"
+
+
+class FakeModerationResponse:
+    def raise_for_status(self) -> None:
+        return None
+
+
+@pytest.fixture()
+def moderation_requests(monkeypatch):
+    requests = []
+
+    def fake_post(url, json, headers, timeout):
+        requests.append(
+            {
+                "url": url,
+                "json": json,
+                "headers": headers,
+                "timeout": timeout,
+            }
+        )
+        return FakeModerationResponse()
+
+    monkeypatch.setattr("src.services.moderation_service.httpx.post", fake_post)
+    return requests
+
+
+@pytest.fixture()
+def product_factory(db_session: Session, category_factory):
+    def create_product(
+        *,
+        seller_id: str = SELLER_ID,
+        status: ProductStatus = ProductStatus.CREATED,
+    ) -> Product:
+        category = category_factory()
+        product = Product(
+            title="iPhone 15 Pro Max",
+            description="Flagship smartphone",
+            seller_id=seller_id,
+            category_id=category.id,
+            status=status,
+        )
+        product.images = [ProductImage(url="/s3/iphone15-front.jpg", ordering=0)]
+        db_session.add(product)
+        db_session.commit()
+        db_session.refresh(product)
+        return product
+
+    return create_product
 
 
 def _assert_validation_error(response):
@@ -46,7 +98,7 @@ def test_create_product_returns_201_with_created_status(client, category_factory
     assert body["characteristics"][0]["id"]
     assert body["characteristics"][0]["name"] == payload["characteristics"][0]["name"]
     assert body["characteristics"][0]["value"] == payload["characteristics"][0]["value"]
-    assert body["seller_id"] == "c3d4e5f6-a7b8-9012-cdef-123456789012"
+    assert body["seller_id"] == SELLER_ID
     _assert_product_response_contract(body)
     assert "created_at" in body
     assert "updated_at" in body
@@ -209,3 +261,60 @@ def test_invalid_title_and_description_return_422_validation_error(
     response = client.post("/api/v1/products", json=payload, headers=auth_headers())
     _assert_validation_error(response)
     assert "description" in response.json()["message"]
+
+
+def test_patch_product_alias_returns_to_on_moderation(
+    client,
+    db_session: Session,
+    product_factory,
+    auth_headers,
+    moderation_requests,
+):
+    product = product_factory(status=ProductStatus.MODERATED)
+
+    response = client.patch(
+        f"/api/v1/products/{str(product.id)}",
+        json={"title": "iPhone 15 Pro Max Updated", "seller_id": "body-seller"},
+        headers=auth_headers(SELLER_ID),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["title"] == "iPhone 15 Pro Max Updated"
+    assert body["seller_id"] == SELLER_ID
+    assert body["status"] == "ON_MODERATION"
+
+    db_session.refresh(product)
+    assert product.status == ProductStatus.ON_MODERATION
+    assert len(moderation_requests) == 1
+    event = moderation_requests[0]["json"]
+    assert event["product_id"] == str(product.id)
+    assert event["seller_id"] == SELLER_ID
+    assert event["event"] == "EDITED"
+    assert event["idempotency_key"]
+
+
+def test_legacy_put_product_edit_route_remains_supported(
+    client,
+    db_session: Session,
+    product_factory,
+    auth_headers,
+    moderation_requests,
+):
+    product = product_factory(status=ProductStatus.BLOCKED)
+
+    response = client.put(
+        f"/api/v1/products/{str(product.id)}",
+        json={"description": "Updated description"},
+        headers=auth_headers(SELLER_ID),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["description"] == "Updated description"
+    assert body["status"] == "ON_MODERATION"
+
+    db_session.refresh(product)
+    assert product.status == ProductStatus.ON_MODERATION
+    assert len(moderation_requests) == 1
+    assert moderation_requests[0]["json"]["event"] == "EDITED"

--- a/tests/api/test_products.py
+++ b/tests/api/test_products.py
@@ -380,7 +380,8 @@ def test_patch_product_response_includes_nested_sku_contract_fields(
     assert response_sku["active_quantity"] == 4
     assert response_sku["reserved_quantity"] == 3
     assert response_sku["article"] == "IPHONE15-BLACK-128"
-    assert response_sku["images"][0]["id"] == f"sku-image:{sku.id}:0"
+    UUID(response_sku["images"][0]["id"])
+    assert response_sku["images"][0]["id"] != str(sku.id)
     assert response_sku["images"][0]["url"] == "/s3/iphone15-black-128.jpg"
     assert response_sku["images"][0]["ordering"] == 0
     assert response_sku["created_at"]

--- a/tests/api/test_skus.py
+++ b/tests/api/test_skus.py
@@ -88,7 +88,7 @@ def sku_count(db_session: Session, product_id: int) -> int:
     return db_session.scalar(select(func.count(SKU.id)).where(SKU.product_id == product_id))
 
 
-def create_existing_sku(db_session: Session, product: Product) -> SKU:
+def create_existing_sku(db_session: Session, product: Product, *, reserved_quantity: int = 0) -> SKU:
     sku = SKU(
         product_id=product.id,
         name="128GB Black",
@@ -97,7 +97,7 @@ def create_existing_sku(db_session: Session, product: Product) -> SKU:
         discount=0,
         image="/s3/iphone15-black-128.jpg",
         active_quantity=0,
-        reserved_quantity=0,
+        reserved_quantity=reserved_quantity,
     )
     db_session.add(sku)
     db_session.commit()
@@ -327,3 +327,165 @@ def test_first_sku_moderation_failure_rolls_back(
     persisted_product = db_session.get(Product, product.id)
     assert persisted_product.status == ProductStatus.CREATED
     assert sku_count(db_session, product.id) == 0
+
+
+def test_edit_moderated_product_returns_to_on_moderation(
+    client,
+    db_session: Session,
+    product_factory,
+    auth_headers,
+    moderation_requests,
+):
+    product = product_factory(status=ProductStatus.MODERATED)
+
+    response = client.put(
+        f"/api/v1/products/{product.id}",
+        json={"title": "iPhone 15 Pro Max Updated", "seller_id": "body-seller"},
+        headers=auth_headers(SELLER_ID),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["title"] == "iPhone 15 Pro Max Updated"
+    assert body["seller_id"] == SELLER_ID
+    assert body["status"] == "ON_MODERATION"
+
+    db_session.refresh(product)
+    assert product.status == ProductStatus.ON_MODERATION
+    assert len(moderation_requests) == 1
+    event = moderation_requests[0]["json"]
+    assert event["product_id"] == product.id
+    assert event["seller_id"] == SELLER_ID
+    assert event["event"] == "EDITED"
+    assert event["idempotency_key"]
+
+
+def test_edit_blocked_product_returns_to_on_moderation(
+    client,
+    db_session: Session,
+    product_factory,
+    auth_headers,
+    moderation_requests,
+):
+    product = product_factory(status=ProductStatus.BLOCKED)
+
+    response = client.put(
+        f"/api/v1/products/{product.id}",
+        json={"description": "Updated description"},
+        headers=auth_headers(SELLER_ID),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["description"] == "Updated description"
+    assert body["status"] == "ON_MODERATION"
+
+    db_session.refresh(product)
+    assert product.status == ProductStatus.ON_MODERATION
+    assert len(moderation_requests) == 1
+    assert moderation_requests[0]["json"]["event"] == "EDITED"
+
+
+def test_reserves_preserved_after_sku_edit(
+    client,
+    db_session: Session,
+    product_factory,
+    auth_headers,
+    moderation_requests,
+):
+    product = product_factory(status=ProductStatus.MODERATED)
+    sku = create_existing_sku(db_session, product, reserved_quantity=7)
+
+    response = client.put(
+        f"/api/v1/skus/{sku.id}",
+        json={
+            "name": "128GB Natural Titanium",
+            "reserved_quantity": 999,
+            "product_id": 999999,
+            "seller_id": "body-seller",
+        },
+        headers=auth_headers(SELLER_ID),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["name"] == "128GB Natural Titanium"
+    assert body["product_id"] == product.id
+    assert body["reserved_quantity"] == 7
+
+    db_session.expire_all()
+    persisted_sku = db_session.get(SKU, sku.id)
+    persisted_product = db_session.get(Product, product.id)
+    assert persisted_sku.product_id == product.id
+    assert persisted_sku.reserved_quantity == 7
+    assert persisted_product.status == ProductStatus.ON_MODERATION
+    assert len(moderation_requests) == 1
+    assert moderation_requests[0]["json"]["event"] == "EDITED"
+
+
+def test_edit_hard_blocked_returns_403(
+    client,
+    db_session: Session,
+    product_factory,
+    auth_headers,
+    moderation_requests,
+):
+    product = product_factory(status=ProductStatus.HARD_BLOCKED)
+    sku = create_existing_sku(db_session, product, reserved_quantity=5)
+
+    product_response = client.put(
+        f"/api/v1/products/{product.id}",
+        json={"title": "Forbidden title"},
+        headers=auth_headers(SELLER_ID),
+    )
+    sku_response = client.put(
+        f"/api/v1/skus/{sku.id}",
+        json={"name": "Forbidden SKU", "reserved_quantity": 999},
+        headers=auth_headers(SELLER_ID),
+    )
+
+    assert product_response.status_code == 403
+    assert sku_response.status_code == 403
+
+    db_session.expire_all()
+    persisted_product = db_session.get(Product, product.id)
+    persisted_sku = db_session.get(SKU, sku.id)
+    assert persisted_product.title == "iPhone 15 Pro Max"
+    assert persisted_product.status == ProductStatus.HARD_BLOCKED
+    assert persisted_sku.name == "128GB Black"
+    assert persisted_sku.reserved_quantity == 5
+    assert moderation_requests == []
+
+
+def test_edit_others_product_returns_403(
+    client,
+    db_session: Session,
+    product_factory,
+    auth_headers,
+    moderation_requests,
+):
+    other_seller_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    product = product_factory(seller_id=SELLER_ID, status=ProductStatus.MODERATED)
+    sku = create_existing_sku(db_session, product)
+
+    product_response = client.put(
+        f"/api/v1/products/{product.id}",
+        json={"title": "Other seller title", "seller_id": SELLER_ID},
+        headers=auth_headers(other_seller_id),
+    )
+    sku_response = client.put(
+        f"/api/v1/skus/{sku.id}",
+        json={"name": "Other seller SKU", "seller_id": SELLER_ID},
+        headers=auth_headers(other_seller_id),
+    )
+
+    assert product_response.status_code == 403
+    assert sku_response.status_code == 403
+
+    db_session.expire_all()
+    persisted_product = db_session.get(Product, product.id)
+    persisted_sku = db_session.get(SKU, sku.id)
+    assert persisted_product.title == "iPhone 15 Pro Max"
+    assert persisted_product.status == ProductStatus.MODERATED
+    assert persisted_sku.name == "128GB Black"
+    assert moderation_requests == []

--- a/tests/api/test_skus.py
+++ b/tests/api/test_skus.py
@@ -354,7 +354,7 @@ def test_patch_moderated_product_returns_to_on_moderation(
     assert product.status == ProductStatus.ON_MODERATION
     assert len(moderation_requests) == 1
     event = moderation_requests[0]["json"]
-    assert event["product_id"] == product.id
+    assert event["product_id"] == str(product.id)
     assert event["seller_id"] == SELLER_ID
     assert event["event"] == "EDITED"
     assert event["idempotency_key"]

--- a/tests/api/test_skus.py
+++ b/tests/api/test_skus.py
@@ -329,7 +329,7 @@ def test_first_sku_moderation_failure_rolls_back(
     assert sku_count(db_session, product.id) == 0
 
 
-def test_edit_moderated_product_returns_to_on_moderation(
+def test_patch_moderated_product_returns_to_on_moderation(
     client,
     db_session: Session,
     product_factory,
@@ -338,7 +338,7 @@ def test_edit_moderated_product_returns_to_on_moderation(
 ):
     product = product_factory(status=ProductStatus.MODERATED)
 
-    response = client.put(
+    response = client.patch(
         f"/api/v1/products/{product.id}",
         json={"title": "iPhone 15 Pro Max Updated", "seller_id": "body-seller"},
         headers=auth_headers(SELLER_ID),
@@ -360,7 +360,7 @@ def test_edit_moderated_product_returns_to_on_moderation(
     assert event["idempotency_key"]
 
 
-def test_edit_blocked_product_returns_to_on_moderation(
+def test_patch_blocked_product_returns_to_on_moderation(
     client,
     db_session: Session,
     product_factory,
@@ -369,7 +369,7 @@ def test_edit_blocked_product_returns_to_on_moderation(
 ):
     product = product_factory(status=ProductStatus.BLOCKED)
 
-    response = client.put(
+    response = client.patch(
         f"/api/v1/products/{product.id}",
         json={"description": "Updated description"},
         headers=auth_headers(SELLER_ID),
@@ -386,7 +386,7 @@ def test_edit_blocked_product_returns_to_on_moderation(
     assert moderation_requests[0]["json"]["event"] == "EDITED"
 
 
-def test_reserves_preserved_after_sku_edit(
+def test_patch_sku_alias_updates_sku(
     client,
     db_session: Session,
     product_factory,
@@ -396,10 +396,11 @@ def test_reserves_preserved_after_sku_edit(
     product = product_factory(status=ProductStatus.MODERATED)
     sku = create_existing_sku(db_session, product, reserved_quantity=7)
 
-    response = client.put(
+    response = client.patch(
         f"/api/v1/skus/{sku.id}",
         json={
             "name": "128GB Natural Titanium",
+            "article": "IPHONE15-NATURAL-128",
             "reserved_quantity": 999,
             "product_id": 999999,
             "seller_id": "body-seller",
@@ -410,20 +411,55 @@ def test_reserves_preserved_after_sku_edit(
     assert response.status_code == 200
     body = response.json()
     assert body["name"] == "128GB Natural Titanium"
-    assert body["product_id"] == product.id
+    assert body["article"] == "IPHONE15-NATURAL-128"
+    assert body["product_id"] == str(product.id)
     assert body["reserved_quantity"] == 7
 
     db_session.expire_all()
     persisted_sku = db_session.get(SKU, sku.id)
     persisted_product = db_session.get(Product, product.id)
     assert persisted_sku.product_id == product.id
+    assert persisted_sku.article == "IPHONE15-NATURAL-128"
     assert persisted_sku.reserved_quantity == 7
     assert persisted_product.status == ProductStatus.ON_MODERATION
     assert len(moderation_requests) == 1
     assert moderation_requests[0]["json"]["event"] == "EDITED"
 
 
-def test_edit_hard_blocked_returns_403(
+def test_legacy_put_sku_edit_route_remains_supported(
+    client,
+    db_session: Session,
+    product_factory,
+    auth_headers,
+    moderation_requests,
+):
+    product = product_factory(status=ProductStatus.CREATED)
+    sku = create_existing_sku(db_session, product, reserved_quantity=3)
+
+    response = client.put(
+        f"/api/v1/skus/{sku.id}",
+        json={"name": "128GB White", "article": "IPHONE15-WHITE-128"},
+        headers=auth_headers(SELLER_ID),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["name"] == "128GB White"
+    assert body["article"] == "IPHONE15-WHITE-128"
+    assert body["product_id"] == str(product.id)
+    assert body["reserved_quantity"] == 3
+
+    db_session.expire_all()
+    persisted_sku = db_session.get(SKU, sku.id)
+    persisted_product = db_session.get(Product, product.id)
+    assert persisted_sku.name == "128GB White"
+    assert persisted_sku.article == "IPHONE15-WHITE-128"
+    assert persisted_sku.reserved_quantity == 3
+    assert persisted_product.status == ProductStatus.CREATED
+    assert moderation_requests == []
+
+
+def test_patch_hard_blocked_returns_403(
     client,
     db_session: Session,
     product_factory,
@@ -433,12 +469,12 @@ def test_edit_hard_blocked_returns_403(
     product = product_factory(status=ProductStatus.HARD_BLOCKED)
     sku = create_existing_sku(db_session, product, reserved_quantity=5)
 
-    product_response = client.put(
+    product_response = client.patch(
         f"/api/v1/products/{product.id}",
         json={"title": "Forbidden title"},
         headers=auth_headers(SELLER_ID),
     )
-    sku_response = client.put(
+    sku_response = client.patch(
         f"/api/v1/skus/{sku.id}",
         json={"name": "Forbidden SKU", "reserved_quantity": 999},
         headers=auth_headers(SELLER_ID),
@@ -457,7 +493,7 @@ def test_edit_hard_blocked_returns_403(
     assert moderation_requests == []
 
 
-def test_edit_others_product_returns_403(
+def test_patch_others_product_returns_403(
     client,
     db_session: Session,
     product_factory,
@@ -468,12 +504,12 @@ def test_edit_others_product_returns_403(
     product = product_factory(seller_id=SELLER_ID, status=ProductStatus.MODERATED)
     sku = create_existing_sku(db_session, product)
 
-    product_response = client.put(
+    product_response = client.patch(
         f"/api/v1/products/{product.id}",
         json={"title": "Other seller title", "seller_id": SELLER_ID},
         headers=auth_headers(other_seller_id),
     )
-    sku_response = client.put(
+    sku_response = client.patch(
         f"/api/v1/skus/{sku.id}",
         json={"name": "Other seller SKU", "seller_id": SELLER_ID},
         headers=auth_headers(other_seller_id),


### PR DESCRIPTION
# US-B2B-03 Summary

Migrated authenticated edit behavior to the authoritative `flow/neomarket-b2b.yaml` contract: `PATCH /api/v1/products/{product_id}` and `PATCH /api/v1/skus/{sku_id}` are now the canonical US-B2B-03 edit endpoints. Existing `PUT /api/v1/products/{id}`, `PUT /api/v1/skus/{id}`, and legacy `PUT /api/v1/skus` remain supported for compatibility. This stacked PR depends on both US-B2B-01 and US-B2B-02 until they are merged into `dev`.

Product edits ignore body `seller_id`, use the Bearer JWT `seller_id` claim for ownership, reject edits to another seller's product, and reject `HARD_BLOCKED` products without persisting changes or sending Moderation events. Edits to `MODERATED` and `BLOCKED` products return the product to `ON_MODERATION` and send a Moderation `EDITED` event.

SKU edits ignore body `reserved_quantity`, `reservedQuantity`, `product_id`, `productId`, `seller_id`, and `sellerId` before validation, preserve persisted `reserved_quantity` and `product_id`, check ownership through the parent product, and reject SKUs whose parent product is `HARD_BLOCKED`. Edits to SKUs under `MODERATED` and `BLOCKED` parent products return the parent product to `ON_MODERATION` and send a Moderation `EDITED` event. SKU `article` can now be updated through the canonical PATCH route and legacy PUT routes.

US-B2B-03 does not add SKU `images[]` update support. Image-management endpoints are separate in the authoritative flow, so this migration keeps edit behavior scoped to existing SKU fields plus `article`.

Added `ProductStatus.BLOCKED` and migration `0004_add_blocked_product_status.py` using `ALTER TYPE product_status ADD VALUE IF NOT EXISTS 'BLOCKED'` inside Alembic `autocommit_block()`. Existing migrations were left unchanged.

Arbiter contract fix: product edit responses now use the ProductResponse-required top-level fields `slug`, `deleted`, `blocking_reason_id`, and `moderator_comment`. Nested product SKUs now include SKUResponse-required fields including `product_id`, `discount`, `cost_price`, `stock_quantity`, `active_quantity`, `reserved_quantity`, `article`, `images`, `created_at`, and `updated_at`. Shared `ImageOut` and `CharacteristicOut` `id` fields are preserved for product images, product characteristics, SKU image response objects, and SKU characteristics.

# US-B2B-03 Validation

Pytest proof commands:

```powershell
python -m pytest tests/api/test_products.py tests/api/test_skus.py -vv -k "test_patch_product_alias_returns_to_on_moderation or test_patch_sku_alias_updates_sku or test_legacy_put_product_edit_route_remains_supported or test_legacy_put_sku_edit_route_remains_supported"
python -m pytest tests/api/test_products.py tests/api/test_skus.py -vv
```

Required scenario results:

- `test_patch_product_alias_returns_to_on_moderation`: passed
- `test_patch_sku_alias_updates_sku`: passed
- `test_legacy_put_product_edit_route_remains_supported`: passed
- `test_legacy_put_sku_edit_route_remains_supported`: passed
- `test_patch_moderated_product_returns_to_on_moderation`: passed
- `test_patch_blocked_product_returns_to_on_moderation`: passed
- `test_patch_hard_blocked_returns_403`: passed
- `test_patch_others_product_returns_403`: passed

Suite results:

- Focused US-B2B-03 route migration scenarios: 4 passed
- `tests/api/test_products.py tests/api/test_skus.py`: 22 passed

Pytest completed without warnings in this run.

# ADR: Edited Moderation Event Idempotency

Options considered:

- Fresh UUID per edit attempt: preserves every accepted edit as a distinct Moderation event and avoids collapsing repeated edits into a single idempotent operation.
- Deterministic key per product: simple and stable, but repeated edits to the same product could collapse into one Moderation event, which does not match the edit flow's need to re-enter moderation after each accepted edit.
- Outbox-generated event identity: operationally stronger, but requires outbox infrastructure beyond this task.

Decision: use a fresh UUID string for each `EDITED` event idempotency key. This is a local assumption because the canonical flow does not define deterministic idempotency semantics for repeated edits.

# ADR: IDOR Ownership Enforcement

Options considered:

- Route/view ownership check: simple to read at the API boundary, but every new endpoint must remember to repeat the check before calling into write logic. Maintenance complexity stays low for one route, then grows as product and SKU endpoints multiply, and the risk of forgetting the check in a new endpoint is high.
- DRF-style permission class: centralizes the concept and can reduce repetition in frameworks built around object permissions, but this service is FastAPI and does not currently have a permission-class layer. Adding one would increase maintenance complexity and introduce a new framework pattern for a small ownership rule.
- Service/query-level ownership check: keeps ownership validation close to the data being modified and matches the existing product/SKU service structure. Maintenance complexity stays low because write paths already go through service functions, and the risk of forgetting the check in a new endpoint is lower when ownership is enforced in the mutation service rather than only in route code.

Decision: enforce product and SKU ownership at the service/query level. This is the smallest fit for this FastAPI service, and product/SKU ownership is already checked close to the data being modified.

# ADR: US-B2B-03 Edit Route Migration Scope

Options considered:

- Replace PUT with PATCH only: matches the authoritative flow exactly, but would break clients already using the previous US-B2B-03 implementation.
- Keep PUT as canonical: lowest code churn, but keeps the implementation out of sync with `flow/neomarket-b2b.yaml`.
- Add PATCH as canonical and keep PUT as compatibility: aligns new clients with the authoritative flow while avoiding an unnecessary breaking change.

Decision: add canonical `PATCH /api/v1/products/{product_id}` and `PATCH /api/v1/skus/{sku_id}` routes that reuse the existing edit services, while keeping the PUT routes as compatibility aliases. SKU `article` is included in update because it is an existing stored SKU field and part of the create/read contract. SKU `images[]` update remains out of scope because image-management endpoints are modeled separately.