### PR TITLE
US-B2B-04: Implement product soft deletion

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -166,9 +166,9 @@ Decision: add canonical `PATCH /api/v1/products/{product_id}` and `PATCH /api/v1
 
 # US-B2B-04 Summary
 
-Implemented soft delete for `DELETE /api/v1/products/{id}` on top of US-B2B-01, US-B2B-02, and US-B2B-03. This remains a stacked change until those earlier slices are merged.
+Implemented soft delete for `DELETE /api/v1/products/{product_id}` on top of US-B2B-01, US-B2B-02, and US-B2B-03. This remains a stacked change until those earlier slices are merged.
 
-The endpoint authenticates the seller from JWT claims, rejects other sellers with `403 NOT_OWNER`, rejects already-deleted products with `400 INVALID_REQUEST`, and marks the product with `deleted=true` without physically deleting products, SKUs, images, characteristics, invoices, or historical data. Successful deletes return `{"ok": true}`.
+The endpoint authenticates the seller from JWT claims, rejects other sellers with `403 NOT_OWNER`, rejects already-deleted products with `400 INVALID_REQUEST`, and marks the product with `deleted=true` without physically deleting products, SKUs, images, characteristics, invoices, or historical data. Successful deletes follow `flow/neomarket-b2b.yaml` and return exactly `204 No Content` with an empty response body.
 
 Added the product `deleted` column and migration `0005_add_product_deleted.py`. Added a minimal seller product list at `GET /api/v1/products` that uses only the JWT seller identity and filters out `deleted=true` products; query parameters such as `seller_id` are not trusted for ownership.
 
@@ -178,10 +178,9 @@ The canonical flow requires UUID idempotency keys but does not define generation
 
 # US-B2B-04 Validation
 
-Pytest proof commands:
+Pytest proof command:
 
 ```powershell
-python -m pytest tests/api/test_products.py -vv -k "test_delete_sets_deleted_true or test_delete_emits_event_to_moderation or test_delete_emits_product_deleted_to_b2c or test_delete_already_deleted_returns_400 or test_delete_others_product_returns_403 or test_deleted_product_not_in_seller_list"
 python -m pytest tests/api/test_products.py tests/api/test_skus.py -vv
 ```
 
@@ -197,7 +196,21 @@ Required scenario results:
 Suite results:
 
 - Required US-B2B-04 scenarios: 6 passed
-- `tests/api/test_products.py tests/api/test_skus.py`: 22 passed
+- `tests/api/test_products.py tests/api/test_skus.py`: 27 passed
+
+Old tests superseded by `flow/neomarket-b2b.yaml`:
+
+- Successful product delete no longer returns `200 {"ok": true}`.
+- Successful product delete now asserts `204 No Content` and an empty response body.
+
+# ADR: Product Delete Contract Source
+
+Options considered:
+
+- Keep the old `flow/b2b-flows.md` success response: preserves the first US-B2B-04 implementation, but conflicts with the authoritative same-path contract.
+- Follow `flow/neomarket-b2b.yaml`: changes only the HTTP success contract while preserving the existing delete business logic and side effects.
+
+Decision: same-path conflicts are resolved in favor of `flow/neomarket-b2b.yaml`. `DELETE /api/v1/products/{product_id}` returns `204 No Content` on success and does not return `{"ok": true}`.
 
 # ADR: Product Delete Event Delivery
 

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -161,3 +161,50 @@ Options considered:
 - Add PATCH as canonical and keep PUT as compatibility: aligns new clients with the authoritative flow while avoiding an unnecessary breaking change.
 
 Decision: add canonical `PATCH /api/v1/products/{product_id}` and `PATCH /api/v1/skus/{sku_id}` routes that reuse the existing edit services, while keeping the PUT routes as compatibility aliases. SKU `article` is included in update because it is an existing stored SKU field and part of the create/read contract. SKU `images[]` update remains out of scope because image-management endpoints are modeled separately.
+
+---
+
+# US-B2B-04 Summary
+
+Implemented soft delete for `DELETE /api/v1/products/{id}` on top of US-B2B-01, US-B2B-02, and US-B2B-03. This remains a stacked change until those earlier slices are merged.
+
+The endpoint authenticates the seller from JWT claims, rejects other sellers with `403 NOT_OWNER`, rejects already-deleted products with `400 INVALID_REQUEST`, and marks the product with `deleted=true` without physically deleting products, SKUs, images, characteristics, invoices, or historical data. Successful deletes return `{"ok": true}`.
+
+Added the product `deleted` column and migration `0005_add_product_deleted.py`. Added a minimal seller product list at `GET /api/v1/products` that uses only the JWT seller identity and filters out `deleted=true` products; query parameters such as `seller_id` are not trusted for ownership.
+
+After committing the soft delete, the service sends best-effort product deletion events to Moderation and B2C. Moderation receives `POST {moderation_url}/api/v1/events/product` with `X-Service-Key: {b2b_to_mod_key}` and payload fields `idempotency_key`, `product_id`, `seller_id`, `event=DELETED`, and `date`. B2C receives `POST {b2c_url}/api/v1/events/product` with `X-Service-Key: {b2b_to_b2c_key}` and payload fields `idempotency_key`, `event=PRODUCT_DELETED`, `product_id`, `sku_ids`, and `date`.
+
+The canonical flow requires UUID idempotency keys but does not define generation semantics; this implementation uses fresh UUIDv4 values for delete events. The flow examples use UUID SKU ids, while this repository persists integer SKU ids, so B2C `sku_ids` are stringified persisted integer ids.
+
+# US-B2B-04 Validation
+
+Pytest proof commands:
+
+```powershell
+python -m pytest tests/api/test_products.py -vv -k "test_delete_sets_deleted_true or test_delete_emits_event_to_moderation or test_delete_emits_product_deleted_to_b2c or test_delete_already_deleted_returns_400 or test_delete_others_product_returns_403 or test_deleted_product_not_in_seller_list"
+python -m pytest tests/api/test_products.py tests/api/test_skus.py -vv
+```
+
+Required scenario results:
+
+- `test_delete_sets_deleted_true`: passed
+- `test_delete_emits_event_to_moderation`: passed
+- `test_delete_emits_product_deleted_to_b2c`: passed
+- `test_delete_already_deleted_returns_400`: passed
+- `test_delete_others_product_returns_403`: passed
+- `test_deleted_product_not_in_seller_list`: passed
+
+Suite results:
+
+- Required US-B2B-04 scenarios: 6 passed
+- `tests/api/test_products.py tests/api/test_skus.py`: 22 passed
+
+# ADR: Product Delete Event Delivery
+
+Options considered:
+
+- Two synchronous POSTs before commit: can roll back the DB if a service is unavailable, but creates external partial inconsistency if the first service receives an event and the second fails before rollback.
+- Outbox for both: best consistency and retry story, but requires a new table, dispatcher, monitoring, and retry semantics outside this assignment.
+- Sync Moderation plus outbox or fire-and-forget B2C: reduces one failure mode, but creates mixed delivery guarantees and still needs infrastructure for one side.
+
+Decision: commit the soft delete first, then synchronously attempt both outbound sends as best-effort operations and log failures. If Moderation or B2C is unavailable, B2B remains deleted and the missing external event is a documented first-iteration inconsistency. Retry and reconciliation should move to an outbox in a future slice.

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -42,7 +42,7 @@ Implemented `POST /api/v1/skus` for B2B SKU creation on top of US-B2B-01 and mig
 
 The SKU endpoint authenticates the seller from JWT claims, verifies that the parent product belongs to that seller, rejects `HARD_BLOCKED` products, and requires only `product_id`, `name`, and `price` in the create request. `cost_price` is optional and nullable, `article` is accepted and returned, and `images[]` is accepted by mapping `images[0].url` to the existing single `skus.image` column. Legacy `image` payloads are still accepted for old clients.
 
-The create response keeps DB IDs as integers internally but serializes SKU `id` and `product_id` as strings at the API boundary. It also returns `article`, `images[]`, `stock_quantity`, `created_at`, and `updated_at` where the existing storage model can support them safely. For the first SKU on a `CREATED` product, the product transitions to `ON_MODERATION` and sends exactly one Moderation `CREATED` event. Additional SKUs on products already in moderation do not send events or change state.
+После принятого UUID root fix ответ создания SKU использует UUID-backed `id` и `product_id` без stringification integer ID на границе ответа. Ответ также возвращает `article`, `images[]`, `stock_quantity`, `created_at` и `updated_at`, где текущая storage model поддерживает эти поля безопасно. Для первого SKU у продукта в статусе `CREATED` продукт переходит в `ON_MODERATION` и отправляет ровно одно событие Moderation `CREATED`. Дополнительные SKU у продуктов, которые уже находятся на модерации, не отправляют события и не меняют статус.
 
 External arbiter response-contract fix: the shared `ImageOut` and `CharacteristicOut` schemas include `id`. SKU characteristics return their persisted row ids. SKU images use a response-boundary synthetic id shaped as `sku-image:{sku.id}:0` because this codebase stores only one `skus.image` URL and has no SKU image table. No DB migration for SKU images is introduced.
 
@@ -164,27 +164,29 @@ Decision: add canonical `PATCH /api/v1/products/{product_id}` and `PATCH /api/v1
 
 ---
 
-# US-B2B-04 Summary
+# US-B2B-04: мягкое удаление продукта
 
-Implemented soft delete for `DELETE /api/v1/products/{product_id}` on top of US-B2B-01, US-B2B-02, and US-B2B-03. This remains a stacked change until those earlier slices are merged.
+Реализовано мягкое удаление для `DELETE /api/v1/products/{product_id}` поверх принятых исправлений US-B2B-01, US-B2B-02 и US-B2B-03. Этот раздел остаётся stacked-изменением до слияния предыдущих срезов.
 
-The endpoint authenticates the seller from JWT claims, rejects other sellers with `403 NOT_OWNER`, rejects already-deleted products with `400 INVALID_REQUEST`, and marks the product with `deleted=true` without physically deleting products, SKUs, images, characteristics, invoices, or historical data. Successful deletes follow `flow/neomarket-b2b.yaml` and return exactly `204 No Content` with an empty response body.
+Эндпоинт берёт продавца только из JWT claims, отклоняет удаление товара другого продавца с `403 NOT_OWNER`, отклоняет повторное удаление уже удалённого товара с `400 INVALID_REQUEST` и помечает товар `deleted=true`. Физическое удаление продукта, SKU, изображений, характеристик, инвойсов и исторических данных не выполняется. Успешное удаление соответствует `flow/neomarket-b2b.yaml`: возвращается ровно `204 No Content` с пустым телом ответа, без `200 {"ok": true}`.
 
-Added the product `deleted` column and migration `0005_add_product_deleted.py`. Added a minimal seller product list at `GET /api/v1/products` that uses only the JWT seller identity and filters out `deleted=true` products; query parameters such as `seller_id` are not trusted for ownership.
+Добавлены колонка продукта `deleted` и миграция `0005_add_product_deleted.py`. Минимальный список товаров продавца `GET /api/v1/products` использует только JWT seller identity и не возвращает товары с `deleted=true`; query-параметры вроде `seller_id` не используются для определения владельца.
 
-After committing the soft delete, the service sends best-effort product deletion events to Moderation and B2C. Moderation receives `POST {moderation_url}/api/v1/events/product` with `X-Service-Key: {b2b_to_mod_key}` and payload fields `idempotency_key`, `product_id`, `seller_id`, `event=DELETED`, and `date`. B2C receives `POST {b2c_url}/api/v1/events/product` with `X-Service-Key: {b2b_to_b2c_key}` and payload fields `idempotency_key`, `event=PRODUCT_DELETED`, `product_id`, `sku_ids`, and `date`.
+После фикса accepted US-B2B-01/02 идентификаторы SKU являются UUID-backed. При отправке события `PRODUCT_DELETED` поле `sku_ids` содержит UUID-строки SKU. В исходящих событиях удаления `product_id` и `seller_id` также передаются как UUID-строки, когда эти поля присутствуют в payload.
 
-The canonical flow requires UUID idempotency keys but does not define generation semantics; this implementation uses fresh UUIDv4 values for delete events. The flow examples use UUID SKU ids, while this repository persists integer SKU ids, so B2C `sku_ids` are stringified persisted integer ids.
+После коммита мягкого удаления сервис best-effort отправляет два каскадных события: событие `DELETED` в Moderation и событие `PRODUCT_DELETED` в B2C. Moderation получает `POST {moderation_url}/api/v1/events/product` с `X-Service-Key: {b2b_to_mod_key}` и полями `idempotency_key`, `product_id`, `seller_id`, `event=DELETED`, `date`. B2C получает `POST {b2c_url}/api/v1/events/product` с `X-Service-Key: {b2b_to_b2c_key}` и полями `idempotency_key`, `event=PRODUCT_DELETED`, `product_id`, `sku_ids`, `date`.
 
-# US-B2B-04 Validation
+Канонический flow требует UUID idempotency keys, но не задаёт семантику генерации; для событий удаления используются свежие UUIDv4.
 
-Pytest proof command:
+# Проверка US-B2B-04
+
+Команда проверки pytest:
 
 ```powershell
 python -m pytest tests/api/test_products.py tests/api/test_skus.py -vv
 ```
 
-Required scenario results:
+Результаты обязательных сценариев:
 
 - `test_delete_sets_deleted_true`: passed
 - `test_delete_emits_event_to_moderation`: passed
@@ -193,31 +195,31 @@ Required scenario results:
 - `test_delete_others_product_returns_403`: passed
 - `test_deleted_product_not_in_seller_list`: passed
 
-Suite results:
+Результаты набора:
 
-- Required US-B2B-04 scenarios: 6 passed
-- `tests/api/test_products.py tests/api/test_skus.py`: 27 passed
+- Обязательные сценарии US-B2B-04: 6 passed
+- `tests/api/test_products.py tests/api/test_skus.py`: 31 passed
 
-Old tests superseded by `flow/neomarket-b2b.yaml`:
+Старые тесты, заменённые контрактом `flow/neomarket-b2b.yaml`:
 
-- Successful product delete no longer returns `200 {"ok": true}`.
-- Successful product delete now asserts `204 No Content` and an empty response body.
+- Успешное удаление продукта больше не возвращает `200 {"ok": true}`.
+- Успешное удаление продукта проверяет `204 No Content` и пустое тело ответа.
 
-# ADR: Product Delete Contract Source
+# ADR: источник контракта удаления продукта
 
-Options considered:
+Рассмотренные варианты:
 
-- Keep the old `flow/b2b-flows.md` success response: preserves the first US-B2B-04 implementation, but conflicts with the authoritative same-path contract.
-- Follow `flow/neomarket-b2b.yaml`: changes only the HTTP success contract while preserving the existing delete business logic and side effects.
+- Оставить старый success response из `flow/b2b-flows.md`: сохраняет первую реализацию US-B2B-04, но конфликтует с authoritative same-path контрактом.
+- Следовать `flow/neomarket-b2b.yaml`: меняет только HTTP-контракт успешного ответа, сохраняя существующую бизнес-логику удаления и side effects.
 
-Decision: same-path conflicts are resolved in favor of `flow/neomarket-b2b.yaml`. `DELETE /api/v1/products/{product_id}` returns `204 No Content` on success and does not return `{"ok": true}`.
+Решение: same-path конфликты разрешаются в пользу `flow/neomarket-b2b.yaml`. `DELETE /api/v1/products/{product_id}` возвращает `204 No Content` при успехе и не возвращает `{"ok": true}`.
 
-# ADR: Product Delete Event Delivery
+# ADR: доставка событий удаления продукта
 
-Options considered:
+Рассмотренные варианты:
 
-- Two synchronous POSTs before commit: can roll back the DB if a service is unavailable, but creates external partial inconsistency if the first service receives an event and the second fails before rollback.
-- Outbox for both: best consistency and retry story, but requires a new table, dispatcher, monitoring, and retry semantics outside this assignment.
-- Sync Moderation plus outbox or fire-and-forget B2C: reduces one failure mode, but creates mixed delivery guarantees and still needs infrastructure for one side.
+- Два синхронных `POST` до commit: позволяют откатить БД, если сервис недоступен, но создают внешнюю частичную рассинхронизацию, если первый сервис получил событие, а второй упал до rollback.
+- Outbox для обоих событий: даёт лучшую консистентность и retry-модель, но требует новую таблицу, dispatcher, monitoring и retry-семантику вне объёма этой задачи.
+- Синхронная Moderation плюс outbox или fire-and-forget для B2C: уменьшает один failure mode, но создаёт смешанные гарантии доставки и всё равно требует инфраструктуру для одной стороны.
 
-Decision: commit the soft delete first, then synchronously attempt both outbound sends as best-effort operations and log failures. If Moderation or B2C is unavailable, B2B remains deleted and the missing external event is a documented first-iteration inconsistency. Retry and reconciliation should move to an outbox in a future slice.
+Решение: сначала фиксировать мягкое удаление, затем синхронно пытаться отправить оба каскадных события в best-effort режиме и логировать ошибки. Если Moderation или B2C недоступны, B2B остаётся в состоянии `deleted=true`, а пропущенное внешнее событие считается документированной first-iteration inconsistency. Retry и reconciliation должны перейти на outbox в будущем срезе.

--- a/migrations/versions/0005_add_product_deleted.py
+++ b/migrations/versions/0005_add_product_deleted.py
@@ -1,0 +1,24 @@
+"""Add product soft delete flag."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0005_add_product_deleted"
+down_revision = "0004_add_blocked_product_status"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "products",
+        sa.Column("deleted", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    op.alter_column("products", "deleted", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column("products", "deleted")

--- a/src/api/routes/products.py
+++ b/src/api/routes/products.py
@@ -1,19 +1,23 @@
 import uuid
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, Response, status
 from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 
 from src.api.deps import CurrentSeller, get_current_seller
 from src.db.session import get_db
-from src.schemas.product import ProductCreate, ProductCreateRead, ProductRead, ProductResponse, ProductUpdate
+from src.schemas.product import ProductCreate, ProductCreateRead, ProductListRead, ProductRead, ProductResponse, ProductUpdate
+from src.services.errors import NotFoundError
 from src.services.product_service import (
     ModerationUnavailableError,
+    ProductAlreadyDeletedError,
     ProductCreateValidationError,
     ProductForbiddenError,
     ProductOwnerError,
     create_product,
+    delete_product,
     get_product_by_id,
+    list_seller_products,
     update_product,
 )
 
@@ -27,15 +31,12 @@ def _field_validation_error(field: str, message: str) -> JSONResponse:
     )
 
 
-def _invalid_request(message: str) -> JSONResponse:
-    return JSONResponse(
-        status_code=400,
-        content={"code": "INVALID_REQUEST", "message": message},
-    )
-
-
 def _error(status_code: int, code: str, message: str) -> JSONResponse:
     return JSONResponse(status_code=status_code, content={"code": code, "message": message})
+
+
+def _invalid_request(message: str) -> JSONResponse:
+    return _error(400, "INVALID_REQUEST", message)
 
 
 @router.post("", response_model=ProductCreateRead, status_code=status.HTTP_201_CREATED)
@@ -53,6 +54,32 @@ async def create_product_endpoint(
         if exc.field == "images":
             return _invalid_request(exc.message)
         return _field_validation_error(exc.field, exc.message)
+
+
+@router.get("", response_model=ProductListRead, status_code=status.HTTP_200_OK)
+def list_products_endpoint(
+    limit: int = 20,
+    offset: int = 0,
+    current_seller: CurrentSeller | JSONResponse = Depends(get_current_seller),
+    db: Session = Depends(get_db),
+) -> ProductListRead | JSONResponse:
+    if isinstance(current_seller, JSONResponse):
+        return current_seller
+
+    bounded_limit = min(max(limit, 1), 100)
+    bounded_offset = max(offset, 0)
+    products, total_count = list_seller_products(
+        db,
+        current_seller.seller_id,
+        limit=bounded_limit,
+        offset=bounded_offset,
+    )
+    return ProductListRead(
+        items=products,
+        total_count=total_count,
+        limit=bounded_limit,
+        offset=bounded_offset,
+    )
 
 
 @router.get("/{id}", response_model=ProductRead, status_code=status.HTTP_200_OK)
@@ -98,3 +125,24 @@ def patch_product_endpoint(
         return _error(403, "FORBIDDEN", str(exc))
     except ModerationUnavailableError:
         return _error(502, "MODERATION_UNAVAILABLE", "Moderation service unavailable")
+
+
+@router.delete("/{id}", response_model=None, status_code=status.HTTP_204_NO_CONTENT)
+def delete_product_endpoint(
+    id: uuid.UUID,
+    current_seller: CurrentSeller | JSONResponse = Depends(get_current_seller),
+    db: Session = Depends(get_db),
+) -> Response | JSONResponse:
+    if isinstance(current_seller, JSONResponse):
+        return current_seller
+
+    try:
+        delete_product(db, id, current_seller.seller_id)
+    except NotFoundError:
+        return _error(404, "NOT_FOUND", "Product not found")
+    except ProductOwnerError as exc:
+        return _error(403, "NOT_OWNER", str(exc))
+    except ProductAlreadyDeletedError as exc:
+        return _invalid_request(str(exc))
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/src/api/routes/products.py
+++ b/src/api/routes/products.py
@@ -127,9 +127,9 @@ def patch_product_endpoint(
         return _error(502, "MODERATION_UNAVAILABLE", "Moderation service unavailable")
 
 
-@router.delete("/{id}", response_model=None, status_code=status.HTTP_204_NO_CONTENT)
+@router.delete("/{product_id}", response_model=None, status_code=status.HTTP_204_NO_CONTENT)
 def delete_product_endpoint(
-    id: uuid.UUID,
+    product_id: uuid.UUID,
     current_seller: CurrentSeller | JSONResponse = Depends(get_current_seller),
     db: Session = Depends(get_db),
 ) -> Response | JSONResponse:
@@ -137,7 +137,7 @@ def delete_product_endpoint(
         return current_seller
 
     try:
-        delete_product(db, id, current_seller.seller_id)
+        delete_product(db, product_id, current_seller.seller_id)
     except NotFoundError:
         return _error(404, "NOT_FOUND", "Product not found")
     except ProductOwnerError as exc:

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -20,6 +20,9 @@ class Settings(BaseSettings):
     moderation_url: str = "http://moderation:8000"
     b2b_to_mod_key: str = "dev-b2b-to-moderation-key"
     moderation_timeout_seconds: float = 3.0
+    b2c_url: str = "http://b2c:8000"
+    b2b_to_b2c_key: str = "dev-b2b-to-b2c-key"
+    b2c_timeout_seconds: float = 3.0
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/src/models/product.py
+++ b/src/models/product.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from enum import Enum
 import uuid
 
-from sqlalchemy import DateTime, Enum as SqlEnum, ForeignKey, Integer, String, Text, func
+from sqlalchemy import Boolean, DateTime, Enum as SqlEnum, ForeignKey, Integer, String, Text, false, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.db.types import GUID
@@ -32,6 +32,7 @@ class Product(Base):
     )
     seller_id: Mapped[uuid.UUID] = mapped_column(GUID(), nullable=False)
     category_id: Mapped[uuid.UUID] = mapped_column(GUID(), ForeignKey("categories.id", ondelete="RESTRICT"))
+    deleted: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default=false())
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         server_default=func.now(),

--- a/src/schemas/product.py
+++ b/src/schemas/product.py
@@ -129,6 +129,7 @@ class ProductRead(APIModel):
     title: str
     description: str
     status: str
+    deleted: bool
     category: CategoryOut
     images: list[ImageOut] = Field(default_factory=list)
     characteristics: list[CharacteristicOut] = Field(default_factory=list)
@@ -152,4 +153,11 @@ class ProductCreateRead(ProductRead):
 
 class ProductResponse(ProductCreateRead):
     skus: list[ProductSKUResponse] = Field(default_factory=list)
+
+
+class ProductListRead(APIModel):
+    items: list[ProductRead]
+    total_count: int
+    limit: int
+    offset: int
 

--- a/src/services/b2c_service.py
+++ b/src/services/b2c_service.py
@@ -1,0 +1,37 @@
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import httpx
+
+from src.core.config import settings
+
+
+class B2CSenderError(Exception):
+    pass
+
+
+def build_product_deleted_event(product_id: int, sku_ids: list[int]) -> dict[str, str | int | list[str]]:
+    return {
+        "idempotency_key": str(uuid4()),
+        "event": "PRODUCT_DELETED",
+        "product_id": product_id,
+        "sku_ids": [str(sku_id) for sku_id in sku_ids],
+        "date": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+    }
+
+
+def send_product_deleted_event(product_id: int, sku_ids: list[int]) -> None:
+    url = f"{settings.b2c_url.rstrip('/')}/api/v1/events/product"
+    headers = {"X-Service-Key": settings.b2b_to_b2c_key}
+    payload = build_product_deleted_event(product_id, sku_ids)
+
+    try:
+        response = httpx.post(
+            url,
+            json=payload,
+            headers=headers,
+            timeout=settings.b2c_timeout_seconds,
+        )
+        response.raise_for_status()
+    except httpx.HTTPError as exc:
+        raise B2CSenderError("B2C service unavailable") from exc

--- a/src/services/moderation_service.py
+++ b/src/services/moderation_service.py
@@ -30,6 +30,16 @@ def build_product_edited_event(product_id: int, seller_id: str) -> dict[str, str
     }
 
 
+def build_product_deleted_event(product_id: int, seller_id: str) -> dict[str, str | int]:
+    return {
+        "idempotency_key": str(uuid4()),
+        "product_id": product_id,
+        "seller_id": seller_id,
+        "event": "DELETED",
+        "date": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+    }
+
+
 def _send_product_event(payload: dict[str, str | int]) -> None:
     url = f"{settings.moderation_url.rstrip('/')}/api/v1/events/product"
     headers = {"X-Service-Key": settings.b2b_to_mod_key}
@@ -52,3 +62,7 @@ def send_product_created_event(product_id: int, seller_id: str) -> None:
 
 def send_product_edited_event(product_id: int, seller_id: str) -> None:
     _send_product_event(build_product_edited_event(product_id, seller_id))
+
+
+def send_product_deleted_event(product_id: int, seller_id: str) -> None:
+    _send_product_event(build_product_deleted_event(product_id, seller_id))

--- a/src/services/product_service.py
+++ b/src/services/product_service.py
@@ -1,12 +1,19 @@
+import logging
 import uuid
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session, selectinload
 
 from src.models import Category, Product, ProductCharacteristic, ProductImage, ProductStatus, SKU
 from src.schemas.product import ProductCreate, ProductUpdate
+from src.services.b2c_service import send_product_deleted_event as send_b2c_product_deleted_event
 from src.services.errors import NotFoundError
-from src.services.moderation_service import send_product_edited_event
+from src.services.moderation_service import (
+    send_product_deleted_event as send_moderation_product_deleted_event,
+    send_product_edited_event,
+)
+
+logger = logging.getLogger(__name__)
 
 
 class ProductCreateValidationError(Exception):
@@ -21,6 +28,10 @@ class ProductForbiddenError(Exception):
 
 
 class ProductOwnerError(Exception):
+    pass
+
+
+class ProductAlreadyDeletedError(Exception):
     pass
 
 
@@ -52,6 +63,19 @@ def get_product_by_id(db: Session, product_id: uuid.UUID) -> Product:
     if product is None:
         raise NotFoundError(f"Product with id={product_id} not found")
     return product
+
+
+def list_seller_products(db: Session, seller_id: uuid.UUID, limit: int = 20, offset: int = 0) -> tuple[list[Product], int]:
+    filters = (Product.seller_id == seller_id, Product.deleted.is_(False))
+    total_count = db.scalar(select(func.count(Product.id)).where(*filters)) or 0
+    products = db.scalars(
+        _product_query()
+        .where(*filters)
+        .order_by(Product.id)
+        .offset(offset)
+        .limit(limit)
+    ).all()
+    return list(products), total_count
 
 
 def create_product(db: Session, payload: ProductCreate, seller_id: uuid.UUID) -> Product:
@@ -121,4 +145,27 @@ def update_product(db: Session, product_id: uuid.UUID, payload: ProductUpdate, s
 
     db.commit()
     return get_product_by_id(db, product_id)
+
+
+def delete_product(db: Session, product_id: uuid.UUID, seller_id: uuid.UUID) -> None:
+    product = get_product_by_id(db, product_id)
+
+    if product.seller_id != seller_id:
+        raise ProductOwnerError("Product does not belong to the authenticated seller")
+    if product.deleted:
+        raise ProductAlreadyDeletedError("Product already deleted")
+
+    sku_ids = [sku.id for sku in product.skus]
+    product.deleted = True
+    db.commit()
+
+    try:
+        send_moderation_product_deleted_event(product_id=str(product.id), seller_id=str(seller_id))
+    except Exception:
+        logger.exception("Failed to send product DELETED event to Moderation")
+
+    try:
+        send_b2c_product_deleted_event(product_id=str(product.id), sku_ids=sku_ids)
+    except Exception:
+        logger.exception("Failed to send PRODUCT_DELETED event to B2C")
 

--- a/tests/api/test_products.py
+++ b/tests/api/test_products.py
@@ -3,15 +3,20 @@ from uuid import UUID, uuid4
 import pytest
 from sqlalchemy.orm import Session
 
+from src.core.config import settings
 from src.models import Product, ProductCharacteristic, ProductImage, ProductStatus, SKU, SKUCharacteristic
 
 
 SELLER_ID = "c3d4e5f6-a7b8-9012-cdef-123456789012"
 
 
-class FakeModerationResponse:
+class FakeEventResponse:
     def raise_for_status(self) -> None:
         return None
+
+
+def assert_uuid(value: str) -> None:
+    UUID(value)
 
 
 @pytest.fixture()
@@ -27,9 +32,29 @@ def moderation_requests(monkeypatch):
                 "timeout": timeout,
             }
         )
-        return FakeModerationResponse()
+        return FakeEventResponse()
 
     monkeypatch.setattr("src.services.moderation_service.httpx.post", fake_post)
+    return requests
+
+
+@pytest.fixture()
+def test_event_requests(monkeypatch):
+    requests = {"moderation": [], "b2c": []}
+
+    def fake_post(url, json, headers, timeout):
+        target = "b2c" if url.startswith(settings.b2c_url) else "moderation"
+        requests[target].append(
+            {
+                "url": url,
+                "json": json,
+                "headers": headers,
+                "timeout": timeout,
+            }
+        )
+        return FakeEventResponse()
+
+    monkeypatch.setattr("httpx.post", fake_post)
     return requests
 
 
@@ -39,6 +64,7 @@ def product_factory(db_session: Session, category_factory):
         *,
         seller_id: str = SELLER_ID,
         status: ProductStatus = ProductStatus.CREATED,
+        deleted: bool = False,
     ) -> Product:
         category = category_factory()
         product = Product(
@@ -47,6 +73,7 @@ def product_factory(db_session: Session, category_factory):
             seller_id=seller_id,
             category_id=category.id,
             status=status,
+            deleted=deleted,
         )
         product.images = [ProductImage(url="/s3/iphone15-front.jpg", ordering=0)]
         product.characteristics = [ProductCharacteristic(name="Brand", value="Apple")]
@@ -56,6 +83,11 @@ def product_factory(db_session: Session, category_factory):
         return product
 
     return create_product
+
+
+@pytest.fixture()
+def test_product_factory(product_factory):
+    return product_factory
 
 
 def _assert_validation_error(response):
@@ -111,6 +143,7 @@ def test_create_product_returns_201_with_created_status(client, category_factory
     assert body["category_id"] == str(category.id)
     assert body["category"]["id"] == str(category.id)
     assert body["status"] == "CREATED"
+    assert body["deleted"] is False
     assert body["skus"] == []
     assert body["images"][0]["id"]
     assert body["images"][0]["url"] == payload["images"][0]["url"]
@@ -390,3 +423,139 @@ def test_patch_product_response_includes_nested_sku_contract_fields(
     assert response_sku["characteristics"][0]["name"] == "Color"
     assert response_sku["characteristics"][0]["value"] == "Black"
     assert moderation_requests == []
+
+
+def test_delete_sets_deleted_true(
+    client,
+    db_session: Session,
+    test_product_factory,
+    auth_headers,
+    test_event_requests,
+):
+    product = test_product_factory()
+
+    response = client.delete(f"/api/v1/products/{product.id}", headers=auth_headers(SELLER_ID))
+
+    assert response.status_code == 204
+    assert response.content == b""
+    db_session.refresh(product)
+    assert product.deleted is True
+
+
+def test_delete_emits_event_to_moderation(
+    client,
+    test_product_factory,
+    auth_headers,
+    test_event_requests,
+):
+    product = test_product_factory()
+
+    response = client.delete(f"/api/v1/products/{product.id}", headers=auth_headers(SELLER_ID))
+
+    assert response.status_code == 204
+    assert response.content == b""
+    assert len(test_event_requests["moderation"]) == 1
+    request = test_event_requests["moderation"][0]
+    event = request["json"]
+    assert request["url"] == f"{settings.moderation_url}/api/v1/events/product"
+    assert request["headers"]["X-Service-Key"] == settings.b2b_to_mod_key
+    assert event["product_id"] == str(product.id)
+    assert event["seller_id"] == SELLER_ID
+    assert event["event"] == "DELETED"
+    assert event["date"]
+    assert_uuid(event["idempotency_key"])
+
+
+def test_delete_emits_product_deleted_to_b2c(
+    client,
+    db_session: Session,
+    test_product_factory,
+    auth_headers,
+    test_event_requests,
+):
+    product = test_product_factory()
+    sku = create_existing_sku(db_session, product)
+
+    response = client.delete(f"/api/v1/products/{product.id}", headers=auth_headers(SELLER_ID))
+
+    assert response.status_code == 204
+    assert response.content == b""
+    assert len(test_event_requests["b2c"]) == 1
+    request = test_event_requests["b2c"][0]
+    event = request["json"]
+    assert request["url"] == f"{settings.b2c_url}/api/v1/events/product"
+    assert request["headers"]["X-Service-Key"] == settings.b2b_to_b2c_key
+    assert event["event"] == "PRODUCT_DELETED"
+    assert event["product_id"] == str(product.id)
+    assert event["sku_ids"] == [str(sku.id)]
+    assert event["date"]
+    assert_uuid(event["idempotency_key"])
+
+
+def test_delete_already_deleted_returns_400(
+    client,
+    test_product_factory,
+    auth_headers,
+    test_event_requests,
+):
+    product = test_product_factory(deleted=True)
+
+    response = client.delete(f"/api/v1/products/{product.id}", headers=auth_headers(SELLER_ID))
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "code": "INVALID_REQUEST",
+        "message": "Product already deleted",
+    }
+    assert test_event_requests == {"moderation": [], "b2c": []}
+
+
+def test_delete_others_product_returns_403(
+    client,
+    db_session: Session,
+    test_product_factory,
+    auth_headers,
+    test_event_requests,
+):
+    product = test_product_factory(seller_id=SELLER_ID)
+    other_seller_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+
+    response = client.delete(f"/api/v1/products/{product.id}", headers=auth_headers(other_seller_id))
+
+    assert response.status_code == 403
+    assert response.json() == {
+        "code": "NOT_OWNER",
+        "message": "Product does not belong to the authenticated seller",
+    }
+    db_session.refresh(product)
+    assert product.deleted is False
+    assert test_event_requests == {"moderation": [], "b2c": []}
+
+
+def test_deleted_product_not_in_seller_list(
+    client,
+    db_session: Session,
+    test_product_factory,
+    auth_headers,
+    test_event_requests,
+):
+    visible_product = test_product_factory()
+    deleted_product = test_product_factory()
+
+    response = client.delete(f"/api/v1/products/{deleted_product.id}", headers=auth_headers(SELLER_ID))
+    assert response.status_code == 204
+    assert response.content == b""
+
+    list_response = client.get(
+        "/api/v1/products",
+        params={"seller_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"},
+        headers=auth_headers(SELLER_ID),
+    )
+
+    assert list_response.status_code == 200
+    body = list_response.json()
+    assert body["total_count"] == 1
+    assert [item["id"] for item in body["items"]] == [str(visible_product.id)]
+
+    db_session.refresh(deleted_product)
+    assert deleted_product.deleted is True


### PR DESCRIPTION
# US-B2B-04: мягкое удаление продукта

Реализовано мягкое удаление для `DELETE /api/v1/products/{product_id}` поверх принятых исправлений US-B2B-01, US-B2B-02 и US-B2B-03. Этот раздел остаётся stacked-изменением до слияния предыдущих срезов.

Эндпоинт берёт продавца только из JWT claims, отклоняет удаление товара другого продавца с `403 NOT_OWNER`, отклоняет повторное удаление уже удалённого товара с `400 INVALID_REQUEST` и помечает товар `deleted=true`. Физическое удаление продукта, SKU, изображений, характеристик, инвойсов и исторических данных не выполняется. Успешное удаление соответствует `flow/neomarket-b2b.yaml`: возвращается ровно `204 No Content` с пустым телом ответа, без `200 {"ok": true}`.

Добавлены колонка продукта `deleted` и миграция `0005_add_product_deleted.py`. Минимальный список товаров продавца `GET /api/v1/products` использует только JWT seller identity и не возвращает товары с `deleted=true`; query-параметры вроде `seller_id` не используются для определения владельца.

После фикса accepted US-B2B-01/02 идентификаторы SKU являются UUID-backed. При отправке события `PRODUCT_DELETED` поле `sku_ids` содержит UUID-строки SKU. В исходящих событиях удаления `product_id` и `seller_id` также передаются как UUID-строки, когда эти поля присутствуют в payload.

После коммита мягкого удаления сервис best-effort отправляет два каскадных события: событие `DELETED` в Moderation и событие `PRODUCT_DELETED` в B2C. Moderation получает `POST {moderation_url}/api/v1/events/product` с `X-Service-Key: {b2b_to_mod_key}` и полями `idempotency_key`, `product_id`, `seller_id`, `event=DELETED`, `date`. B2C получает `POST {b2c_url}/api/v1/events/product` с `X-Service-Key: {b2b_to_b2c_key}` и полями `idempotency_key`, `event=PRODUCT_DELETED`, `product_id`, `sku_ids`, `date`.

Канонический flow требует UUID idempotency keys, но не задаёт семантику генерации; для событий удаления используются свежие UUIDv4.

# Проверка US-B2B-04

Команда проверки pytest:

```powershell
python -m pytest tests/api/test_products.py tests/api/test_skus.py -vv
```

Результаты обязательных сценариев:

- `test_delete_sets_deleted_true`: passed
- `test_delete_emits_event_to_moderation`: passed
- `test_delete_emits_product_deleted_to_b2c`: passed
- `test_delete_already_deleted_returns_400`: passed
- `test_delete_others_product_returns_403`: passed
- `test_deleted_product_not_in_seller_list`: passed

Результаты набора:

- Обязательные сценарии US-B2B-04: 6 passed
- `tests/api/test_products.py tests/api/test_skus.py`: 31 passed

Старые тесты, заменённые контрактом `flow/neomarket-b2b.yaml`:

- Успешное удаление продукта больше не возвращает `200 {"ok": true}`.
- Успешное удаление продукта проверяет `204 No Content` и пустое тело ответа.

# ADR: источник контракта удаления продукта

Рассмотренные варианты:

- Оставить старый success response из `flow/b2b-flows.md`: сохраняет первую реализацию US-B2B-04, но конфликтует с authoritative same-path контрактом.
- Следовать `flow/neomarket-b2b.yaml`: меняет только HTTP-контракт успешного ответа, сохраняя существующую бизнес-логику удаления и side effects.

Решение: same-path конфликты разрешаются в пользу `flow/neomarket-b2b.yaml`. `DELETE /api/v1/products/{product_id}` возвращает `204 No Content` при успехе и не возвращает `{"ok": true}`.

# ADR: доставка событий удаления продукта

Рассмотренные варианты:

- Два синхронных `POST` до commit: позволяют откатить БД, если сервис недоступен, но создают внешнюю частичную рассинхронизацию, если первый сервис получил событие, а второй упал до rollback.
- Outbox для обоих событий: даёт лучшую консистентность и retry-модель, но требует новую таблицу, dispatcher, monitoring и retry-семантику вне объёма этой задачи.
- Синхронная Moderation плюс outbox или fire-and-forget для B2C: уменьшает один failure mode, но создаёт смешанные гарантии доставки и всё равно требует инфраструктуру для одной стороны.

Решение: сначала фиксировать мягкое удаление, затем синхронно пытаться отправить оба каскадных события в best-effort режиме и логировать ошибки. Если Moderation или B2C недоступны, B2B остаётся в состоянии `deleted=true`, а пропущенное внешнее событие считается документированной first-iteration inconsistency. Retry и reconciliation должны перейти на outbox в будущем срезе.