### PR TITLE
US-B2B-05: Implement product card view

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -223,3 +223,47 @@ python -m pytest tests/api/test_products.py tests/api/test_skus.py -vv
 - Синхронная Moderation плюс outbox или fire-and-forget для B2C: уменьшает один failure mode, но создаёт смешанные гарантии доставки и всё равно требует инфраструктуру для одной стороны.
 
 Решение: сначала фиксировать мягкое удаление, затем синхронно пытаться отправить оба каскадных события в best-effort режиме и логировать ошибки. Если Moderation или B2C недоступны, B2B остаётся в состоянии `deleted=true`, а пропущенное внешнее событие считается документированной first-iteration inconsistency. Retry и reconciliation должны перейти на outbox в будущем срезе.
+Decision: commit the soft delete first, then synchronously attempt both outbound sends as best-effort operations and log failures. If Moderation or B2C is unavailable, B2B remains deleted and the missing external event is a documented first-iteration inconsistency. Retry and reconciliation should move to an outbox in a future slice.
+
+---
+
+# US-B2B-05 Summary
+
+Implemented seller-mode `GET /api/v1/products/{id}` on top of US-B2B-01, US-B2B-02, US-B2B-03, and US-B2B-04. This remains a stacked change until those earlier slices are merged.
+
+The endpoint authenticates the seller from Bearer JWT claims, uses only the JWT `seller_id` for ownership, and returns the same canonical `404 {"code":"NOT_FOUND","message":"Product not found"}` for nonexistent products and products owned by another seller. Seller detail also hides `deleted=true` products with the same 404, while internal service queries can still load deleted products where prior behavior needs it, such as already-deleted delete detection.
+
+Added nullable product JSON fields `blocking_reason` and `field_reports` with migration `0006_add_product_blocking_fields.py`. Seller detail returns a seller-specific response shape with `blocked`, full category/images/characteristics, seller-only SKU fields `cost_price` and `reserved_quantity`, and blocking fields. Non-blocking statuses return `blocking_reason=null` and `field_reports=[]`; blocked products return stored blocking data.
+
+The seller detail response preserves the accepted UUID-backed contract from US-B2B-01 and US-B2B-02: product, category, image, characteristic, and nested SKU ids are UUID values, nested SKU images are returned as `images[]`, and no integer-id response serialization is reintroduced.
+
+# US-B2B-05 Validation
+
+Pytest proof commands:
+
+```powershell
+python -m pytest tests/api/test_products.py -vv -k "test_get_moderated_product_returns_full_payload or test_get_blocked_product_returns_blocking_reason_and_field_reports or test_get_others_product_returns_404 or test_get_nonexistent_returns_404"
+python -m pytest tests/api/test_products.py tests/api/test_skus.py -vv
+```
+
+Required scenario results:
+
+- `test_get_moderated_product_returns_full_payload`: passed
+- `test_get_blocked_product_returns_blocking_reason_and_field_reports`: passed
+- `test_get_others_product_returns_404`: passed
+- `test_get_nonexistent_returns_404`: passed
+
+Suite results:
+
+- Required US-B2B-05 scenarios: 4 passed
+- `tests/api/test_products.py tests/api/test_skus.py`: 26 passed
+
+# ADR: Seller Product Detail Shape
+
+Options considered:
+
+- One view with auth/header branching: less code, but weaker readability and the highest risk of leaking `cost_price` or `reserved_quantity` into B2C mode.
+- Two separate views/schemas: clearer code and the lowest leakage risk; this is the best future direction for seller, B2C, and interservice modes.
+- Permission/auth-mode dependency: centralizes mode detection, but adds a new framework pattern and still requires careful schema separation.
+
+Decision: implement seller-mode only now with a seller-specific route dependency, service lookup, and response schema. Future B2C and interservice modes should use separate route handlers and schemas rather than branching this seller response.

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -229,13 +229,13 @@ Decision: commit the soft delete first, then synchronously attempt both outbound
 
 # US-B2B-05 Summary
 
-Implemented seller-mode `GET /api/v1/products/{id}` on top of US-B2B-01, US-B2B-02, US-B2B-03, and US-B2B-04. This remains a stacked change until those earlier slices are merged.
+Migrated `GET /api/v1/products/{id}` to the dual-mode detail behavior from `flow/neomarket-b2b.yaml` on top of US-B2B-01 through US-B2B-04. This remains a stacked change until those earlier slices are merged.
 
-The endpoint authenticates the seller from Bearer JWT claims, uses only the JWT `seller_id` for ownership, and returns the same canonical `404 {"code":"NOT_FOUND","message":"Product not found"}` for nonexistent products and products owned by another seller. Seller detail also hides `deleted=true` products with the same 404, while internal service queries can still load deleted products where prior behavior needs it, such as already-deleted delete detection.
+When `X-Service-Key` is absent, the endpoint stays in seller mode: it authenticates the seller from Bearer JWT claims, uses only the JWT `seller_id` for ownership, and returns the same canonical `404 {"code":"NOT_FOUND","message":"Product not found"}` for nonexistent products, deleted products, and products owned by another seller. Seller detail keeps the existing seller-only fields, including `cost_price`, `reserved_quantity`, `blocking_reason`, and `field_reports`.
 
-Added nullable product JSON fields `blocking_reason` and `field_reports` with migration `0006_add_product_blocking_fields.py`. Seller detail returns a seller-specific response shape with `blocked`, full category/images/characteristics, seller-only SKU fields `cost_price` and `reserved_quantity`, and blocking fields. Non-blocking statuses return `blocking_reason=null` and `field_reports=[]`; blocked products return stored blocking data.
+When a valid `X-Service-Key` is present, the endpoint uses public B2C mode and does not require or trust Bearer JWT. Invalid or empty service keys return `401 {"code":"UNAUTHORIZED","message":"Authorization required"}`, even if an Authorization header is also present. Public mode only returns products that are `MODERATED`, not deleted, and have at least one SKU with `active_quantity > 0`; blocked, deleted, nonexistent, and out-of-stock products return the same 404.
 
-The seller detail response preserves the accepted UUID-backed contract from US-B2B-01 and US-B2B-02: product, category, image, characteristic, and nested SKU ids are UUID values, nested SKU images are returned as `images[]`, and no integer-id response serialization is reintroduced.
+Seller and public detail responses preserve the accepted UUID-backed contract from US-B2B-01 and US-B2B-02: product, category, image, characteristic, and nested SKU ids are UUID values, nested SKU images are returned as `images[]`, and no integer-id response serialization is reintroduced. Public detail uses separate response schemas to omit seller-only fields, includes only in-stock public SKUs, maps public `stock_quantity` to `active_quantity`, and keeps `active_quantity` because the schema requires it.
 
 # US-B2B-05 Validation
 
@@ -243,6 +243,7 @@ Pytest proof commands:
 
 ```powershell
 python -m pytest tests/api/test_products.py -vv -k "test_get_moderated_product_returns_full_payload or test_get_blocked_product_returns_blocking_reason_and_field_reports or test_get_others_product_returns_404 or test_get_nonexistent_returns_404"
+python -m pytest tests/api/test_products.py -vv -k "test_get_moderated_product_returns_full_payload or test_get_blocked_product_returns_blocking_reason_and_field_reports or test_get_others_product_returns_404 or test_get_nonexistent_returns_404 or test_public_product_detail_with_valid_service_key_returns_public_payload or test_public_product_detail_hides_seller_only_fields or test_public_product_detail_invalid_service_key_returns_401 or test_public_product_detail_blocked_product_returns_404 or test_public_product_detail_deleted_product_returns_404 or test_public_product_detail_without_active_sku_returns_404"
 python -m pytest tests/api/test_products.py tests/api/test_skus.py -vv
 ```
 
@@ -252,18 +253,24 @@ Required scenario results:
 - `test_get_blocked_product_returns_blocking_reason_and_field_reports`: passed
 - `test_get_others_product_returns_404`: passed
 - `test_get_nonexistent_returns_404`: passed
+- `test_public_product_detail_with_valid_service_key_returns_public_payload`: passed
+- `test_public_product_detail_hides_seller_only_fields`: passed
+- `test_public_product_detail_invalid_service_key_returns_401`: passed
+- `test_public_product_detail_blocked_product_returns_404`: passed
+- `test_public_product_detail_deleted_product_returns_404`: passed
+- `test_public_product_detail_without_active_sku_returns_404`: passed
 
 Suite results:
 
-- Required US-B2B-05 scenarios: 4 passed
-- `tests/api/test_products.py tests/api/test_skus.py`: 26 passed
+- Required US-B2B-05 seller/public detail scenarios: 10 passed
+- `tests/api/test_products.py tests/api/test_skus.py`: 37 passed
 
 # ADR: Seller Product Detail Shape
 
 Options considered:
 
-- One view with auth/header branching: less code, but weaker readability and the highest risk of leaking `cost_price` or `reserved_quantity` into B2C mode.
-- Two separate views/schemas: clearer code and the lowest leakage risk; this is the best future direction for seller, B2C, and interservice modes.
-- Permission/auth-mode dependency: centralizes mode detection, but adds a new framework pattern and still requires careful schema separation.
+- Keep seller JWT only on this path: lowest change, but conflicts with `flow/neomarket-b2b.yaml`, where the same product detail endpoint also supports service-key public detail.
+- Add separate public routes now: cleaner long-term separation, but public catalog routes belong to US-B2B-07 and are out of scope for this migration.
+- Use a single route with an auth-mode dependency and separate response schemas: keeps the path aligned with the authoritative detail contract while limiting the change to product detail and reducing leakage risk through schema separation.
 
-Decision: implement seller-mode only now with a seller-specific route dependency, service lookup, and response schema. Future B2C and interservice modes should use separate route handlers and schemas rather than branching this seller response.
+Decision: use a single `GET /api/v1/products/{id}` route with explicit auth-mode detection. `X-Service-Key` takes precedence when present, invalid service keys fail closed, and seller JWT handling is preserved for the no-service-key path. Seller and public modes use separate service lookups and separate response schemas so seller-only fields are not serialized in public mode.

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -237,6 +237,8 @@ When a valid `X-Service-Key` is present, the endpoint uses public B2C mode and d
 
 Seller and public detail responses preserve the accepted UUID-backed contract from US-B2B-01 and US-B2B-02: product, category, image, characteristic, and nested SKU ids are UUID values, nested SKU images are returned as `images[]`, and no integer-id response serialization is reintroduced. Public detail uses separate response schemas to omit seller-only fields, includes only in-stock public SKUs, maps public `stock_quantity` to `active_quantity`, and keeps `active_quantity` because the schema requires it.
 
+External arbiter contract fix: seller detail now includes ProductResponse-required top-level fields `slug`, `blocking_reason_id`, and `moderator_comment` while keeping the enriched `blocking_reason` and `field_reports` details for blocked products. Seller detail nested SKUs now include SKUResponse-required fields `product_id`, `stock_quantity`, `article`, `images`, `created_at`, and `updated_at` alongside seller-only `cost_price` and `reserved_quantity`. Seller SKU images are returned as `images[]` with stable synthetic response-only ids shaped as `sku-image:{sku.id}:0` because this codebase stores only one `skus.image` URL and has no SKU image table. The shared `ImageOut` and `CharacteristicOut` `id` fix is preserved, and the public view remains seller-data-safe by hiding `cost_price`, `reserved_quantity`, `blocking_reason`, and `field_reports`.
+
 # US-B2B-05 Validation
 
 Pytest proof commands:

--- a/migrations/versions/0006_add_product_blocking_fields.py
+++ b/migrations/versions/0006_add_product_blocking_fields.py
@@ -1,0 +1,22 @@
+"""Add product blocking feedback fields."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0006_add_product_blocking_fields"
+down_revision = "0005_add_product_deleted"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("products", sa.Column("blocking_reason", sa.JSON(), nullable=True))
+    op.add_column("products", sa.Column("field_reports", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("products", "field_reports")
+    op.drop_column("products", "blocking_reason")

--- a/src/api/deps.py
+++ b/src/api/deps.py
@@ -3,10 +3,10 @@ import base64
 import hashlib
 import hmac
 import json
-from typing import Any
+from typing import Any, Literal
 import uuid
 
-from fastapi import Depends
+from fastapi import Depends, Header
 from fastapi.responses import JSONResponse
 from fastapi.security import OAuth2PasswordBearer
 
@@ -18,6 +18,12 @@ oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/auth/login", auto_error=Fals
 @dataclass(frozen=True)
 class CurrentSeller:
     seller_id: uuid.UUID
+
+
+@dataclass(frozen=True)
+class ProductDetailAccess:
+    mode: Literal["seller", "public"]
+    seller_id: uuid.UUID | None = None
 
 
 def unauthorized_response() -> JSONResponse:
@@ -56,7 +62,7 @@ def _decode_hs256_token(token: str) -> dict[str, Any] | None:
     return payload if isinstance(payload, dict) else None
 
 
-def get_current_seller(token: str | None = Depends(oauth2_scheme)) -> CurrentSeller | JSONResponse:
+def _current_seller_from_token(token: str | None) -> CurrentSeller | JSONResponse:
     if not token:
         return unauthorized_response()
 
@@ -71,3 +77,22 @@ def get_current_seller(token: str | None = Depends(oauth2_scheme)) -> CurrentSel
         return unauthorized_response()
 
     return CurrentSeller(seller_id=seller_uuid)
+
+
+def get_current_seller(token: str | None = Depends(oauth2_scheme)) -> CurrentSeller | JSONResponse:
+    return _current_seller_from_token(token)
+
+
+def get_product_detail_access(
+    x_service_key: str | None = Header(default=None, alias="X-Service-Key"),
+    token: str | None = Depends(oauth2_scheme),
+) -> ProductDetailAccess | JSONResponse:
+    if x_service_key is not None:
+        if not x_service_key.strip() or not hmac.compare_digest(x_service_key, settings.b2c_to_b2b_key):
+            return unauthorized_response()
+        return ProductDetailAccess(mode="public")
+
+    current_seller = _current_seller_from_token(token)
+    if isinstance(current_seller, JSONResponse):
+        return current_seller
+    return ProductDetailAccess(mode="seller", seller_id=current_seller.seller_id)

--- a/src/api/routes/products.py
+++ b/src/api/routes/products.py
@@ -4,12 +4,13 @@ from fastapi import APIRouter, Depends, Response, status
 from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 
-from src.api.deps import CurrentSeller, get_current_seller
+from src.api.deps import CurrentSeller, ProductDetailAccess, get_current_seller, get_product_detail_access
 from src.db.session import get_db
 from src.schemas.product import (
     ProductCreate,
     ProductCreateRead,
     ProductListRead,
+    ProductPublicRead,
     ProductResponse,
     ProductUpdate,
     SellerProductRead,
@@ -23,6 +24,7 @@ from src.services.product_service import (
     ProductOwnerError,
     create_product,
     delete_product,
+    get_public_product_by_id,
     get_seller_product_by_id,
     list_seller_products,
     update_product,
@@ -89,17 +91,19 @@ def list_products_endpoint(
     )
 
 
-@router.get("/{id}", response_model=SellerProductRead, status_code=status.HTTP_200_OK)
+@router.get("/{id}", response_model=None, status_code=status.HTTP_200_OK)
 def get_product_endpoint(
     id: uuid.UUID,
-    current_seller: CurrentSeller | JSONResponse = Depends(get_current_seller),
+    access: ProductDetailAccess | JSONResponse = Depends(get_product_detail_access),
     db: Session = Depends(get_db),
-) -> SellerProductRead | JSONResponse:
-    if isinstance(current_seller, JSONResponse):
-        return current_seller
+) -> SellerProductRead | ProductPublicRead | JSONResponse:
+    if isinstance(access, JSONResponse):
+        return access
 
     try:
-        return get_seller_product_by_id(db, id, current_seller.seller_id)
+        if access.mode == "public":
+            return ProductPublicRead.model_validate(get_public_product_by_id(db, id))
+        return SellerProductRead.model_validate(get_seller_product_by_id(db, id, access.seller_id or ""))
     except NotFoundError:
         return _error(404, "NOT_FOUND", "Product not found")
 

--- a/src/api/routes/products.py
+++ b/src/api/routes/products.py
@@ -6,7 +6,14 @@ from sqlalchemy.orm import Session
 
 from src.api.deps import CurrentSeller, get_current_seller
 from src.db.session import get_db
-from src.schemas.product import ProductCreate, ProductCreateRead, ProductListRead, ProductRead, ProductResponse, ProductUpdate
+from src.schemas.product import (
+    ProductCreate,
+    ProductCreateRead,
+    ProductListRead,
+    ProductResponse,
+    ProductUpdate,
+    SellerProductRead,
+)
 from src.services.errors import NotFoundError
 from src.services.product_service import (
     ModerationUnavailableError,
@@ -16,7 +23,7 @@ from src.services.product_service import (
     ProductOwnerError,
     create_product,
     delete_product,
-    get_product_by_id,
+    get_seller_product_by_id,
     list_seller_products,
     update_product,
 )
@@ -82,9 +89,19 @@ def list_products_endpoint(
     )
 
 
-@router.get("/{id}", response_model=ProductRead, status_code=status.HTTP_200_OK)
-def get_product_endpoint(id: uuid.UUID, db: Session = Depends(get_db)) -> ProductRead:
-    return get_product_by_id(db, id)
+@router.get("/{id}", response_model=SellerProductRead, status_code=status.HTTP_200_OK)
+def get_product_endpoint(
+    id: uuid.UUID,
+    current_seller: CurrentSeller | JSONResponse = Depends(get_current_seller),
+    db: Session = Depends(get_db),
+) -> SellerProductRead | JSONResponse:
+    if isinstance(current_seller, JSONResponse):
+        return current_seller
+
+    try:
+        return get_seller_product_by_id(db, id, current_seller.seller_id)
+    except NotFoundError:
+        return _error(404, "NOT_FOUND", "Product not found")
 
 
 @router.put("/{id}", response_model=ProductResponse, status_code=status.HTTP_200_OK)

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -22,6 +22,7 @@ class Settings(BaseSettings):
     moderation_timeout_seconds: float = 3.0
     b2c_url: str = "http://b2c:8000"
     b2b_to_b2c_key: str = "dev-b2b-to-b2c-key"
+    b2c_to_b2b_key: str = "dev-b2c-to-b2b-key"
     b2c_timeout_seconds: float = 3.0
 
     model_config = SettingsConfigDict(

--- a/src/models/product.py
+++ b/src/models/product.py
@@ -1,8 +1,9 @@
 from datetime import datetime
 from enum import Enum
+from typing import Any
 import uuid
 
-from sqlalchemy import Boolean, DateTime, Enum as SqlEnum, ForeignKey, Integer, String, Text, false, func
+from sqlalchemy import Boolean, DateTime, Enum as SqlEnum, ForeignKey, Integer, JSON, String, Text, false, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.db.types import GUID
@@ -33,6 +34,8 @@ class Product(Base):
     seller_id: Mapped[uuid.UUID] = mapped_column(GUID(), nullable=False)
     category_id: Mapped[uuid.UUID] = mapped_column(GUID(), ForeignKey("categories.id", ondelete="RESTRICT"))
     deleted: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default=false())
+    blocking_reason: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+    field_reports: Mapped[list[dict[str, Any]] | None] = mapped_column(JSON, nullable=True, default=list)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         server_default=func.now(),
@@ -44,6 +47,10 @@ class Product(Base):
         onupdate=func.now(),
         nullable=False,
     )
+
+    @property
+    def blocked(self) -> bool:
+        return self.status in {ProductStatus.BLOCKED, ProductStatus.HARD_BLOCKED}
 
     category = relationship("Category", back_populates="products")
     images = relationship(

--- a/src/schemas/product.py
+++ b/src/schemas/product.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from typing import Any
 import uuid
 
-from pydantic import AliasChoices, Field, computed_field, model_validator
+from pydantic import AliasChoices, Field, computed_field, field_validator, model_validator
 
 from src.schemas.common import (
     APIModel,
@@ -57,6 +57,10 @@ class ProductSKURead(APIModel):
     def add_synthetic_images(cls, value: Any) -> Any:
         image = value.get("image") if isinstance(value, dict) else getattr(value, "image", None)
         sku_id = value.get("id") if isinstance(value, dict) else getattr(value, "id")
+        active_quantity = value.get("active_quantity", 0) if isinstance(value, dict) else getattr(value, "active_quantity", 0)
+        reserved_quantity = (
+            value.get("reserved_quantity", 0) if isinstance(value, dict) else getattr(value, "reserved_quantity", 0)
+        )
         image_data = []
         if image:
             image_id = uuid.uuid5(SKU_IMAGE_NAMESPACE, f"sku-image:{sku_id}:0")
@@ -66,6 +70,7 @@ class ProductSKURead(APIModel):
             value = value.copy()
             if value.get("cost_price") is None:
                 value["cost_price"] = 0
+            value.setdefault("stock_quantity", active_quantity + reserved_quantity)
             if image:
                 value.setdefault("images", image_data)
             return value
@@ -77,9 +82,9 @@ class ProductSKURead(APIModel):
             "price": value.price,
             "discount": getattr(value, "discount", 0),
             "cost_price": getattr(value, "cost_price", None) or 0,
-            "stock_quantity": getattr(value, "stock_quantity", 0),
+            "stock_quantity": active_quantity + reserved_quantity,
             "active_quantity": value.active_quantity,
-            "reserved_quantity": getattr(value, "reserved_quantity", 0),
+            "reserved_quantity": reserved_quantity,
             "article": getattr(value, "article", None),
             "images": image_data,
             "characteristics": getattr(value, "characteristics", []),
@@ -122,6 +127,10 @@ class ProductSKUResponse(APIModel):
         ]
 
 
+class SellerProductSKURead(ProductSKURead):
+    pass
+
+
 class ProductRead(APIModel):
     id: uuid.UUID
     seller_id: uuid.UUID
@@ -136,7 +145,6 @@ class ProductRead(APIModel):
     skus: list[ProductSKURead] = Field(default_factory=list)
     created_at: datetime
     updated_at: datetime
-    deleted: bool = False
     blocking_reason_id: str | None = None
     moderator_comment: str | None = None
 
@@ -153,6 +161,18 @@ class ProductCreateRead(ProductRead):
 
 class ProductResponse(ProductCreateRead):
     skus: list[ProductSKUResponse] = Field(default_factory=list)
+
+
+class SellerProductRead(ProductRead):
+    blocked: bool
+    skus: list[SellerProductSKURead] = Field(default_factory=list)
+    blocking_reason: dict[str, Any] | None = None
+    field_reports: list[dict[str, Any]] = Field(default_factory=list)
+
+    @field_validator("field_reports", mode="before")
+    @classmethod
+    def default_field_reports(cls, value):
+        return [] if value is None else value
 
 
 class ProductListRead(APIModel):

--- a/src/schemas/product.py
+++ b/src/schemas/product.py
@@ -214,6 +214,28 @@ class SellerProductRead(ProductRead):
     blocking_reason: dict[str, Any] | None = None
     field_reports: list[dict[str, Any]] = Field(default_factory=list)
 
+    @computed_field
+    @property
+    def slug(self) -> str:
+        value = re.sub(r"[^a-z0-9]+", "-", self.title.lower()).strip("-")
+        return f"{value or 'product'}-{self.id}"
+
+    @computed_field
+    @property
+    def blocking_reason_id(self) -> str | None:
+        if not self.blocking_reason:
+            return None
+        value = self.blocking_reason.get("id")
+        return str(value) if value is not None else None
+
+    @computed_field
+    @property
+    def moderator_comment(self) -> str | None:
+        if not self.blocking_reason:
+            return None
+        value = self.blocking_reason.get("comment")
+        return str(value) if value is not None else None
+
     @field_validator("field_reports", mode="before")
     @classmethod
     def default_field_reports(cls, value):

--- a/src/schemas/product.py
+++ b/src/schemas/product.py
@@ -131,6 +131,51 @@ class SellerProductSKURead(ProductSKURead):
     pass
 
 
+class SKUPublicRead(APIModel):
+    id: uuid.UUID
+    product_id: uuid.UUID
+    name: str
+    price: int
+    discount: int
+    active_quantity: int
+    article: str | None = None
+    image: str = Field(default="", exclude=True)
+    images: list[ImageOut] = Field(default_factory=list)
+    characteristics: list[CharacteristicOut] = Field(default_factory=list)
+
+    @model_validator(mode="before")
+    @classmethod
+    def add_synthetic_images(cls, value: Any) -> Any:
+        image = value.get("image") if isinstance(value, dict) else getattr(value, "image", None)
+        if not image:
+            return value
+
+        sku_id = value.get("id") if isinstance(value, dict) else getattr(value, "id")
+        image_id = uuid.uuid5(SKU_IMAGE_NAMESPACE, f"sku-image:{sku_id}:0")
+        image_data = [{"id": image_id, "url": image, "ordering": 0}]
+
+        if isinstance(value, dict):
+            value = value.copy()
+            value.setdefault("images", image_data)
+            return value
+
+        return {
+            "id": value.id,
+            "product_id": value.product_id,
+            "name": value.name,
+            "price": value.price,
+            "discount": getattr(value, "discount", 0),
+            "active_quantity": value.active_quantity,
+            "article": getattr(value, "article", None),
+            "images": image_data,
+            "characteristics": getattr(value, "characteristics", []),
+        }
+
+    @computed_field
+    @property
+    def stock_quantity(self) -> int:
+        return self.active_quantity
+
 class ProductRead(APIModel):
     id: uuid.UUID
     seller_id: uuid.UUID
@@ -173,6 +218,33 @@ class SellerProductRead(ProductRead):
     @classmethod
     def default_field_reports(cls, value):
         return [] if value is None else value
+
+
+class ProductPublicRead(APIModel):
+    id: uuid.UUID
+    seller_id: uuid.UUID
+    category_id: uuid.UUID
+    title: str
+    description: str
+    status: str
+    images: list[ImageOut] = Field(default_factory=list)
+    characteristics: list[CharacteristicOut] = Field(default_factory=list)
+    skus: list[SKUPublicRead] = Field(default_factory=list)
+    created_at: datetime
+    updated_at: datetime
+
+    @computed_field
+    @property
+    def slug(self) -> str:
+        value = re.sub(r"[^a-z0-9]+", "-", self.title.lower()).strip("-")
+        return f"{value or 'product'}-{self.id}"
+
+    @field_validator("skus", mode="before")
+    @classmethod
+    def only_active_skus(cls, value):
+        if value is None:
+            return []
+        return [sku for sku in value if getattr(sku, "active_quantity", 0) > 0]
 
 
 class ProductListRead(APIModel):

--- a/src/schemas/product.py
+++ b/src/schemas/product.py
@@ -176,6 +176,7 @@ class SKUPublicRead(APIModel):
     def stock_quantity(self) -> int:
         return self.active_quantity
 
+
 class ProductRead(APIModel):
     id: uuid.UUID
     seller_id: uuid.UUID
@@ -199,6 +200,42 @@ class ProductRead(APIModel):
         value = re.sub(r"[^a-z0-9]+", "-", self.title.lower()).strip("-")
         return f"{value or 'product'}-{self.id}"
 
+    @model_validator(mode="before")
+    @classmethod
+    def add_blocking_summary(cls, value: Any) -> Any:
+        blocking_reason = value.get("blocking_reason") if isinstance(value, dict) else getattr(value, "blocking_reason", None)
+        if not blocking_reason:
+            return value
+
+        blocking_reason_id = blocking_reason.get("id")
+        moderator_comment = blocking_reason.get("comment")
+        if isinstance(value, dict):
+            value = value.copy()
+            value.setdefault("blocking_reason_id", str(blocking_reason_id) if blocking_reason_id is not None else None)
+            value.setdefault("moderator_comment", str(moderator_comment) if moderator_comment is not None else None)
+            return value
+
+        return {
+            "id": value.id,
+            "seller_id": value.seller_id,
+            "category_id": value.category_id,
+            "title": value.title,
+            "description": value.description,
+            "status": value.status,
+            "deleted": value.deleted,
+            "category": value.category,
+            "images": value.images,
+            "characteristics": value.characteristics,
+            "skus": value.skus,
+            "created_at": value.created_at,
+            "updated_at": value.updated_at,
+            "blocking_reason_id": str(blocking_reason_id) if blocking_reason_id is not None else None,
+            "moderator_comment": str(moderator_comment) if moderator_comment is not None else None,
+            "blocked": getattr(value, "blocked", False),
+            "blocking_reason": blocking_reason,
+            "field_reports": getattr(value, "field_reports", []),
+        }
+
 
 class ProductCreateRead(ProductRead):
     pass
@@ -213,28 +250,6 @@ class SellerProductRead(ProductRead):
     skus: list[SellerProductSKURead] = Field(default_factory=list)
     blocking_reason: dict[str, Any] | None = None
     field_reports: list[dict[str, Any]] = Field(default_factory=list)
-
-    @computed_field
-    @property
-    def slug(self) -> str:
-        value = re.sub(r"[^a-z0-9]+", "-", self.title.lower()).strip("-")
-        return f"{value or 'product'}-{self.id}"
-
-    @computed_field
-    @property
-    def blocking_reason_id(self) -> str | None:
-        if not self.blocking_reason:
-            return None
-        value = self.blocking_reason.get("id")
-        return str(value) if value is not None else None
-
-    @computed_field
-    @property
-    def moderator_comment(self) -> str | None:
-        if not self.blocking_reason:
-            return None
-        value = self.blocking_reason.get("comment")
-        return str(value) if value is not None else None
 
     @field_validator("field_reports", mode="before")
     @classmethod

--- a/src/services/product_service.py
+++ b/src/services/product_service.py
@@ -65,6 +65,19 @@ def get_product_by_id(db: Session, product_id: uuid.UUID) -> Product:
     return product
 
 
+def get_seller_product_by_id(db: Session, product_id: uuid.UUID, seller_id: uuid.UUID) -> Product:
+    product = db.scalars(
+        _product_query().where(
+            Product.id == product_id,
+            Product.seller_id == seller_id,
+            Product.deleted.is_(False),
+        )
+    ).first()
+    if product is None:
+        raise NotFoundError(f"Product with id={product_id} not found")
+    return product
+
+
 def list_seller_products(db: Session, seller_id: uuid.UUID, limit: int = 20, offset: int = 0) -> tuple[list[Product], int]:
     filters = (Product.seller_id == seller_id, Product.deleted.is_(False))
     total_count = db.scalar(select(func.count(Product.id)).where(*filters)) or 0

--- a/src/services/product_service.py
+++ b/src/services/product_service.py
@@ -78,6 +78,20 @@ def get_seller_product_by_id(db: Session, product_id: uuid.UUID, seller_id: uuid
     return product
 
 
+def get_public_product_by_id(db: Session, product_id: uuid.UUID) -> Product:
+    product = db.scalars(
+        _product_query().where(
+            Product.id == product_id,
+            Product.status == ProductStatus.MODERATED,
+            Product.deleted.is_(False),
+            Product.skus.any(SKU.active_quantity > 0),
+        )
+    ).first()
+    if product is None:
+        raise NotFoundError(f"Product with id={product_id} not found")
+    return product
+
+
 def list_seller_products(db: Session, seller_id: uuid.UUID, limit: int = 20, offset: int = 0) -> tuple[list[Product], int]:
     filters = (Product.seller_id == seller_id, Product.deleted.is_(False))
     total_count = db.scalar(select(func.count(Product.id)).where(*filters)) or 0

--- a/tests/api/test_products.py
+++ b/tests/api/test_products.py
@@ -203,9 +203,9 @@ def test_get_moderated_product_returns_full_payload(
 
     assert response.status_code == 200
     body = response.json()
-    assert body["id"] == product.id
+    assert body["id"] == str(product.id)
     assert body["seller_id"] == SELLER_ID
-    assert body["category_id"] == product.category_id
+    assert body["category_id"] == str(product.category_id)
     assert body["title"] == product.title
     assert body["description"] == product.description
     assert body["status"] == "MODERATED"
@@ -214,7 +214,7 @@ def test_get_moderated_product_returns_full_payload(
     assert body["blocking_reason_id"] is None
     assert body["moderator_comment"] is None
     assert body["blocked"] is False
-    assert body["category"] == {"id": product.category.id, "name": product.category.name}
+    assert body["category"] == {"id": str(product.category.id), "name": product.category.name}
     assert body["images"][0]["id"]
     assert body["images"][0]["url"] == "/s3/iphone15-front.jpg"
     assert body["images"][0]["ordering"] == 0
@@ -233,7 +233,7 @@ def test_get_moderated_product_returns_full_payload(
     assert response_sku["stock_quantity"] == 12
     assert response_sku["reserved_quantity"] == 2
     assert response_sku["article"] is None
-    assert response_sku["images"][0]["id"] == f"sku-image:{sku.id}:0"
+    assert_uuid(response_sku["images"][0]["id"])
     assert response_sku["images"][0]["url"] == "/s3/iphone15-black-128.jpg"
     assert response_sku["images"][0]["ordering"] == 0
     assert response_sku["characteristics"][0]["id"]
@@ -297,7 +297,7 @@ def test_get_others_product_returns_404(client, test_product_factory, auth_heade
 
 
 def test_get_nonexistent_returns_404(client, auth_headers):
-    response = client.get("/api/v1/products/999999", headers=auth_headers(SELLER_ID))
+    response = client.get(f"/api/v1/products/{uuid4()}", headers=auth_headers(SELLER_ID))
 
     assert response.status_code == 404
     assert response.json() == {"code": "NOT_FOUND", "message": "Product not found"}
@@ -357,7 +357,8 @@ def test_public_product_detail_with_valid_service_key_returns_public_payload(
         }
     ]
     assert len(body["skus"]) == 1
-    assert body["skus"][0] == {
+    response_sku = body["skus"][0]
+    assert response_sku == {
         "id": str(active_sku.id),
         "product_id": str(product.id),
         "name": "128GB Black",
@@ -373,8 +374,15 @@ def test_public_product_detail_with_valid_service_key_returns_public_payload(
             }
         ],
         "stock_quantity": 8,
-        "images": [{"url": "/s3/iphone15-black-128.jpg", "ordering": 0}],
+        "images": [
+            {
+                "id": response_sku["images"][0]["id"],
+                "url": "/s3/iphone15-black-128.jpg",
+                "ordering": 0,
+            }
+        ],
     }
+    assert_uuid(response_sku["images"][0]["id"])
     assert test_event_requests == {"moderation": [], "b2c": []}
 
 
@@ -493,6 +501,7 @@ def test_get_product_returns_product_and_nested_sku_contract_fields(
     client,
     db_session: Session,
     category_factory,
+    auth_headers,
 ):
     category = category_factory()
     product = Product(
@@ -516,7 +525,7 @@ def test_get_product_returns_product_and_nested_sku_contract_fields(
     db_session.add(product)
     db_session.commit()
 
-    response = client.get(f"/api/v1/products/{product.id}")
+    response = client.get(f"/api/v1/products/{product.id}", headers=auth_headers(str(product.seller_id)))
 
     assert response.status_code == 200
     body = response.json()
@@ -533,7 +542,7 @@ def test_get_product_returns_product_and_nested_sku_contract_fields(
     assert sku_body["price"] == sku.price
     assert sku_body["discount"] == 0
     assert sku_body["cost_price"] == 0
-    assert sku_body["stock_quantity"] == 0
+    assert sku_body["stock_quantity"] == sku.active_quantity
     assert sku_body["active_quantity"] == sku.active_quantity
     assert sku_body["reserved_quantity"] == 0
     assert sku_body["article"] is None

--- a/tests/api/test_products.py
+++ b/tests/api/test_products.py
@@ -49,6 +49,10 @@ def assert_uuid(value: str) -> None:
     UUID(value)
 
 
+def public_headers(key: str | None = None) -> dict[str, str]:
+    return {"X-Service-Key": key or settings.b2c_to_b2b_key}
+
+
 @pytest.fixture()
 def moderation_requests(monkeypatch):
     requests = []
@@ -282,6 +286,167 @@ def test_get_others_product_returns_404(client, test_product_factory, auth_heade
 
 def test_get_nonexistent_returns_404(client, auth_headers):
     response = client.get("/api/v1/products/999999", headers=auth_headers(SELLER_ID))
+
+    assert response.status_code == 404
+    assert response.json() == {"code": "NOT_FOUND", "message": "Product not found"}
+
+
+def test_public_product_detail_with_valid_service_key_returns_public_payload(
+    client,
+    db_session: Session,
+    test_product_factory,
+    test_event_requests,
+):
+    product = test_product_factory(status=ProductStatus.MODERATED)
+    active_sku = create_existing_sku(
+        db_session,
+        product,
+        active_quantity=8,
+        reserved_quantity=3,
+        discount=0,
+        article="IPHONE15-BLACK-128",
+        characteristic_name="Storage",
+        characteristic_value="128GB",
+    )
+    create_existing_sku(
+        db_session,
+        product,
+        active_quantity=0,
+        discount=0,
+        article=None,
+        image="",
+        characteristic_name="Storage",
+        characteristic_value="128GB",
+    )
+
+    response = client.get(f"/api/v1/products/{product.id}", headers=public_headers())
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == str(product.id)
+    assert body["seller_id"] == SELLER_ID
+    assert body["category_id"] == str(product.category_id)
+    assert body["title"] == product.title
+    assert body["slug"] == f"iphone-15-pro-max-{product.id}"
+    assert body["description"] == product.description
+    assert body["status"] == "MODERATED"
+    assert body["images"] == [
+        {
+            "id": str(product.images[0].id),
+            "url": "/s3/iphone15-front.jpg",
+            "ordering": 0,
+        }
+    ]
+    assert body["characteristics"] == [
+        {
+            "id": str(product.characteristics[0].id),
+            "name": "Brand",
+            "value": "Apple",
+        }
+    ]
+    assert len(body["skus"]) == 1
+    assert body["skus"][0] == {
+        "id": str(active_sku.id),
+        "product_id": str(product.id),
+        "name": "128GB Black",
+        "price": 9999000,
+        "discount": 0,
+        "active_quantity": 8,
+        "article": "IPHONE15-BLACK-128",
+        "characteristics": [
+            {
+                "id": str(active_sku.characteristics[0].id),
+                "name": "Storage",
+                "value": "128GB",
+            }
+        ],
+        "stock_quantity": 8,
+        "images": [{"url": "/s3/iphone15-black-128.jpg", "ordering": 0}],
+    }
+    assert test_event_requests == {"moderation": [], "b2c": []}
+
+
+def test_public_product_detail_hides_seller_only_fields(
+    client,
+    db_session: Session,
+    test_product_factory,
+):
+    product = test_product_factory(
+        status=ProductStatus.MODERATED,
+        blocking_reason={"title": "Seller-only reason"},
+        field_reports=[{"field_name": "title", "comment": "Seller-only report"}],
+    )
+    create_existing_sku(db_session, product, active_quantity=5, reserved_quantity=7)
+
+    response = client.get(f"/api/v1/products/{product.id}", headers=public_headers())
+
+    assert response.status_code == 200
+    body = response.json()
+    assert "deleted" not in body
+    assert "blocking_reason" not in body
+    assert "field_reports" not in body
+    assert "moderator_comment" not in body
+    assert "blocking_reason_id" not in body
+
+    sku = body["skus"][0]
+    assert "cost_price" not in sku
+    assert "reserved_quantity" not in sku
+    assert sku["active_quantity"] == 5
+    assert sku["stock_quantity"] == 5
+
+
+def test_public_product_detail_invalid_service_key_returns_401(
+    client,
+    test_product_factory,
+    auth_headers,
+):
+    product = test_product_factory(status=ProductStatus.MODERATED)
+    headers = auth_headers(SELLER_ID)
+    headers["X-Service-Key"] = "wrong-key"
+
+    response = client.get(f"/api/v1/products/{product.id}", headers=headers)
+
+    assert response.status_code == 401
+    assert response.json() == {"code": "UNAUTHORIZED", "message": "Authorization required"}
+
+
+def test_public_product_detail_blocked_product_returns_404(
+    client,
+    db_session: Session,
+    test_product_factory,
+):
+    product = test_product_factory(status=ProductStatus.BLOCKED)
+    create_existing_sku(db_session, product, active_quantity=5)
+
+    response = client.get(f"/api/v1/products/{product.id}", headers=public_headers())
+
+    assert response.status_code == 404
+    assert response.json() == {"code": "NOT_FOUND", "message": "Product not found"}
+
+
+def test_public_product_detail_deleted_product_returns_404(
+    client,
+    db_session: Session,
+    test_product_factory,
+):
+    product = test_product_factory(status=ProductStatus.MODERATED, deleted=True)
+    create_existing_sku(db_session, product, active_quantity=5)
+
+    response = client.get(f"/api/v1/products/{product.id}", headers=public_headers())
+
+    assert response.status_code == 404
+    assert response.json() == {"code": "NOT_FOUND", "message": "Product not found"}
+
+
+def test_public_product_detail_without_active_sku_returns_404(
+    client,
+    db_session: Session,
+    test_product_factory,
+):
+    product = test_product_factory(status=ProductStatus.MODERATED)
+    create_existing_sku(db_session, product, active_quantity=0, reserved_quantity=4)
+
+    response = client.get(f"/api/v1/products/{product.id}", headers=public_headers())
 
     assert response.status_code == 404
     assert response.json() == {"code": "NOT_FOUND", "message": "Product not found"}

--- a/tests/api/test_products.py
+++ b/tests/api/test_products.py
@@ -210,6 +210,9 @@ def test_get_moderated_product_returns_full_payload(
     assert body["description"] == product.description
     assert body["status"] == "MODERATED"
     assert body["deleted"] is False
+    assert body["slug"] == f"iphone-15-pro-max-{product.id}"
+    assert body["blocking_reason_id"] is None
+    assert body["moderator_comment"] is None
     assert body["blocked"] is False
     assert body["category"] == {"id": product.category.id, "name": product.category.name}
     assert body["images"][0]["id"]
@@ -220,17 +223,24 @@ def test_get_moderated_product_returns_full_payload(
     assert body["characteristics"][0]["value"] == "Apple"
     assert len(body["skus"]) == 1
     response_sku = body["skus"][0]
-    assert response_sku["id"] == sku.id
+    assert response_sku["id"] == str(sku.id)
+    assert response_sku["product_id"] == str(product.id)
     assert response_sku["name"] == "128GB Black"
     assert response_sku["price"] == 9999000
     assert response_sku["cost_price"] == 7000000
     assert response_sku["discount"] == 0
-    assert response_sku["image"] == "/s3/iphone15-black-128.jpg"
     assert response_sku["active_quantity"] == 10
+    assert response_sku["stock_quantity"] == 12
     assert response_sku["reserved_quantity"] == 2
+    assert response_sku["article"] is None
+    assert response_sku["images"][0]["id"] == f"sku-image:{sku.id}:0"
+    assert response_sku["images"][0]["url"] == "/s3/iphone15-black-128.jpg"
+    assert response_sku["images"][0]["ordering"] == 0
     assert response_sku["characteristics"][0]["id"]
     assert response_sku["characteristics"][0]["name"] == "Storage"
     assert response_sku["characteristics"][0]["value"] == "128GB"
+    assert response_sku["created_at"]
+    assert response_sku["updated_at"]
     assert body["blocking_reason"] is None
     assert body["field_reports"] == []
     assert "created_at" in body
@@ -268,6 +278,8 @@ def test_get_blocked_product_returns_blocking_reason_and_field_reports(
     body = response.json()
     assert body["status"] == "BLOCKED"
     assert body["blocked"] is True
+    assert body["blocking_reason_id"] == blocking_reason["id"]
+    assert body["moderator_comment"] == blocking_reason["comment"]
     assert body["blocking_reason"]["title"] == "Description does not match product"
     assert body["blocking_reason"] == blocking_reason
     assert body["field_reports"] == field_reports

--- a/tests/api/test_products.py
+++ b/tests/api/test_products.py
@@ -15,6 +15,36 @@ class FakeEventResponse:
         return None
 
 
+def create_existing_sku(
+    db_session: Session,
+    product: Product,
+    *,
+    image: str = "/s3/iphone15-black-128.jpg",
+    active_quantity: int = 4,
+    reserved_quantity: int = 3,
+    discount: int = 10,
+    article: str | None = "IPHONE15-BLACK-128",
+    characteristic_name: str = "Color",
+    characteristic_value: str = "Black",
+) -> SKU:
+    sku = SKU(
+        product_id=product.id,
+        name="128GB Black",
+        price=9999000,
+        cost_price=7000000,
+        discount=discount,
+        article=article,
+        image=image,
+        active_quantity=active_quantity,
+        reserved_quantity=reserved_quantity,
+    )
+    sku.characteristics = [SKUCharacteristic(name=characteristic_name, value=characteristic_value)]
+    db_session.add(sku)
+    db_session.commit()
+    db_session.refresh(sku)
+    return sku
+
+
 def assert_uuid(value: str) -> None:
     UUID(value)
 
@@ -65,6 +95,8 @@ def product_factory(db_session: Session, category_factory):
         seller_id: str = SELLER_ID,
         status: ProductStatus = ProductStatus.CREATED,
         deleted: bool = False,
+        blocking_reason: dict | None = None,
+        field_reports: list[dict] | None = None,
     ) -> Product:
         category = category_factory()
         product = Product(
@@ -74,6 +106,8 @@ def product_factory(db_session: Session, category_factory):
             category_id=category.id,
             status=status,
             deleted=deleted,
+            blocking_reason=blocking_reason,
+            field_reports=field_reports,
         )
         product.images = [ProductImage(url="/s3/iphone15-front.jpg", ordering=0)]
         product.characteristics = [ProductCharacteristic(name="Brand", value="Apple")]
@@ -111,25 +145,6 @@ def _assert_product_response_contract(body: dict) -> None:
     assert body["moderator_comment"] is None
 
 
-def create_existing_sku(db_session: Session, product: Product, *, image: str = "/s3/iphone15-black-128.jpg") -> SKU:
-    sku = SKU(
-        product_id=product.id,
-        name="128GB Black",
-        price=9999000,
-        cost_price=7000000,
-        discount=10,
-        article="IPHONE15-BLACK-128",
-        image=image,
-        active_quantity=4,
-        reserved_quantity=3,
-    )
-    sku.characteristics = [SKUCharacteristic(name="Color", value="Black")]
-    db_session.add(sku)
-    db_session.commit()
-    db_session.refresh(sku)
-    return sku
-
-
 def test_create_product_returns_201_with_created_status(client, category_factory, product_payload_factory, auth_headers):
     category = category_factory()
     payload = product_payload_factory(category.id)
@@ -160,6 +175,116 @@ def test_create_product_returns_201_with_created_status(client, category_factory
     _assert_uuid(body["seller_id"])
     _assert_uuid(body["images"][0]["id"])
     _assert_uuid(body["characteristics"][0]["id"])
+
+
+def test_get_moderated_product_returns_full_payload(
+    client,
+    db_session: Session,
+    test_product_factory,
+    auth_headers,
+):
+    product = test_product_factory(status=ProductStatus.MODERATED)
+    sku = create_existing_sku(
+        db_session,
+        product,
+        active_quantity=10,
+        reserved_quantity=2,
+        discount=0,
+        article=None,
+        characteristic_name="Storage",
+        characteristic_value="128GB",
+    )
+
+    response = client.get(f"/api/v1/products/{product.id}", headers=auth_headers(SELLER_ID))
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == product.id
+    assert body["seller_id"] == SELLER_ID
+    assert body["category_id"] == product.category_id
+    assert body["title"] == product.title
+    assert body["description"] == product.description
+    assert body["status"] == "MODERATED"
+    assert body["deleted"] is False
+    assert body["blocked"] is False
+    assert body["category"] == {"id": product.category.id, "name": product.category.name}
+    assert body["images"][0]["id"]
+    assert body["images"][0]["url"] == "/s3/iphone15-front.jpg"
+    assert body["images"][0]["ordering"] == 0
+    assert body["characteristics"][0]["id"]
+    assert body["characteristics"][0]["name"] == "Brand"
+    assert body["characteristics"][0]["value"] == "Apple"
+    assert len(body["skus"]) == 1
+    response_sku = body["skus"][0]
+    assert response_sku["id"] == sku.id
+    assert response_sku["name"] == "128GB Black"
+    assert response_sku["price"] == 9999000
+    assert response_sku["cost_price"] == 7000000
+    assert response_sku["discount"] == 0
+    assert response_sku["image"] == "/s3/iphone15-black-128.jpg"
+    assert response_sku["active_quantity"] == 10
+    assert response_sku["reserved_quantity"] == 2
+    assert response_sku["characteristics"][0]["id"]
+    assert response_sku["characteristics"][0]["name"] == "Storage"
+    assert response_sku["characteristics"][0]["value"] == "128GB"
+    assert body["blocking_reason"] is None
+    assert body["field_reports"] == []
+    assert "created_at" in body
+    assert "updated_at" in body
+
+
+def test_get_blocked_product_returns_blocking_reason_and_field_reports(
+    client,
+    db_session: Session,
+    test_product_factory,
+    auth_headers,
+):
+    blocking_reason = {
+        "id": "a7b8c9d0-1234-5678-ef01-890123456789",
+        "title": "Description does not match product",
+        "comment": "Photos and description are inconsistent",
+    }
+    field_reports = [
+        {
+            "field_name": "description",
+            "sku_id": None,
+            "comment": "Description mentions another material",
+        }
+    ]
+    product = test_product_factory(
+        status=ProductStatus.BLOCKED,
+        blocking_reason=blocking_reason,
+        field_reports=field_reports,
+    )
+    create_existing_sku(db_session, product)
+
+    response = client.get(f"/api/v1/products/{product.id}", headers=auth_headers(SELLER_ID))
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "BLOCKED"
+    assert body["blocked"] is True
+    assert body["blocking_reason"]["title"] == "Description does not match product"
+    assert body["blocking_reason"] == blocking_reason
+    assert body["field_reports"] == field_reports
+    assert isinstance(body["field_reports"], list)
+
+
+def test_get_others_product_returns_404(client, test_product_factory, auth_headers):
+    product = test_product_factory(seller_id=SELLER_ID)
+    other_seller_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+
+    response = client.get(f"/api/v1/products/{product.id}", headers=auth_headers(other_seller_id))
+
+    assert response.status_code == 404
+    assert response.json() == {"code": "NOT_FOUND", "message": "Product not found"}
+
+
+def test_get_nonexistent_returns_404(client, auth_headers):
+    response = client.get("/api/v1/products/999999", headers=auth_headers(SELLER_ID))
+
+    assert response.status_code == 404
+    assert response.json() == {"code": "NOT_FOUND", "message": "Product not found"}
 
 
 def test_seller_id_taken_from_jwt(


### PR DESCRIPTION
# US-B2B-05 Summary

Migrated `GET /api/v1/products/{id}` to the dual-mode detail behavior from `flow/neomarket-b2b.yaml` on top of US-B2B-01 through US-B2B-04. This remains a stacked change until those earlier slices are merged.

When `X-Service-Key` is absent, the endpoint stays in seller mode: it authenticates the seller from Bearer JWT claims, uses only the JWT `seller_id` for ownership, and returns the same canonical `404 {"code":"NOT_FOUND","message":"Product not found"}` for nonexistent products, deleted products, and products owned by another seller. Seller detail keeps the existing seller-only fields, including `cost_price`, `reserved_quantity`, `blocking_reason`, and `field_reports`.

When a valid `X-Service-Key` is present, the endpoint uses public B2C mode and does not require or trust Bearer JWT. Invalid or empty service keys return `401 {"code":"UNAUTHORIZED","message":"Authorization required"}`, even if an Authorization header is also present. Public mode only returns products that are `MODERATED`, not deleted, and have at least one SKU with `active_quantity > 0`; blocked, deleted, nonexistent, and out-of-stock products return the same 404.

Seller and public detail responses preserve the accepted UUID-backed contract from US-B2B-01 and US-B2B-02: product, category, image, characteristic, and nested SKU ids are UUID values, nested SKU images are returned as `images[]`, and no integer-id response serialization is reintroduced. Public detail uses separate response schemas to omit seller-only fields, includes only in-stock public SKUs, maps public `stock_quantity` to `active_quantity`, and keeps `active_quantity` because the schema requires it.

External arbiter contract fix: seller detail now includes ProductResponse-required top-level fields `slug`, `blocking_reason_id`, and `moderator_comment` while keeping the enriched `blocking_reason` and `field_reports` details for blocked products. Seller detail nested SKUs now include SKUResponse-required fields `product_id`, `stock_quantity`, `article`, `images`, `created_at`, and `updated_at` alongside seller-only `cost_price` and `reserved_quantity`. Seller SKU images are returned as `images[]` with stable synthetic response-only ids shaped as `sku-image:{sku.id}:0` because this codebase stores only one `skus.image` URL and has no SKU image table. The shared `ImageOut` and `CharacteristicOut` `id` fix is preserved, and the public view remains seller-data-safe by hiding `cost_price`, `reserved_quantity`, `blocking_reason`, and `field_reports`.

# US-B2B-05 Validation

Pytest proof commands:

```powershell
python -m pytest tests/api/test_products.py -vv -k "test_get_moderated_product_returns_full_payload or test_get_blocked_product_returns_blocking_reason_and_field_reports or test_get_others_product_returns_404 or test_get_nonexistent_returns_404"
python -m pytest tests/api/test_products.py -vv -k "test_get_moderated_product_returns_full_payload or test_get_blocked_product_returns_blocking_reason_and_field_reports or test_get_others_product_returns_404 or test_get_nonexistent_returns_404 or test_public_product_detail_with_valid_service_key_returns_public_payload or test_public_product_detail_hides_seller_only_fields or test_public_product_detail_invalid_service_key_returns_401 or test_public_product_detail_blocked_product_returns_404 or test_public_product_detail_deleted_product_returns_404 or test_public_product_detail_without_active_sku_returns_404"
python -m pytest tests/api/test_products.py tests/api/test_skus.py -vv
```

Required scenario results:

- `test_get_moderated_product_returns_full_payload`: passed
- `test_get_blocked_product_returns_blocking_reason_and_field_reports`: passed
- `test_get_others_product_returns_404`: passed
- `test_get_nonexistent_returns_404`: passed
- `test_public_product_detail_with_valid_service_key_returns_public_payload`: passed
- `test_public_product_detail_hides_seller_only_fields`: passed
- `test_public_product_detail_invalid_service_key_returns_401`: passed
- `test_public_product_detail_blocked_product_returns_404`: passed
- `test_public_product_detail_deleted_product_returns_404`: passed
- `test_public_product_detail_without_active_sku_returns_404`: passed

Suite results:

- Required US-B2B-05 seller/public detail scenarios: 10 passed
- `tests/api/test_products.py tests/api/test_skus.py`: 37 passed

# ADR: Seller Product Detail Shape

Options considered:

- Keep seller JWT only on this path: lowest change, but conflicts with `flow/neomarket-b2b.yaml`, where the same product detail endpoint also supports service-key public detail.
- Add separate public routes now: cleaner long-term separation, but public catalog routes belong to US-B2B-07 and are out of scope for this migration.
- Use a single route with an auth-mode dependency and separate response schemas: keeps the path aligned with the authoritative detail contract while limiting the change to product detail and reducing leakage risk through schema separation.

Decision: use a single `GET /api/v1/products/{id}` route with explicit auth-mode detection. `X-Service-Key` takes precedence when present, invalid service keys fail closed, and seller JWT handling is preserved for the no-service-key path. Seller and public modes use separate service lookups and separate response schemas so seller-only fields are not serialized in public mode.