### PR TITLE
US-B2B-06: Implement invoice creation

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -285,11 +285,11 @@ Implemented seller-facing `POST /api/v1/invoices` for inbound product supply inv
 
 This PR is stacked on top of US-B2B-01, US-B2B-02, US-B2B-03, US-B2B-04, and US-B2B-05 until they are merged into dev.
 
-The endpoint authenticates the seller from Bearer JWT claims, ignores any body `seller_id`/`sellerId`, validates every requested SKU through its parent product ownership, and only allows SKUs whose parent product is exactly `MODERATED` and not deleted. Invoice creation stores a document with `status=PENDING`, requested item quantities, and `accepted_quantity=null`; it does not change `active_quantity`, `reserved_quantity`, or accepted stock.
+The endpoint authenticates the seller from Bearer JWT claims, ignores any body `seller_id`/`sellerId`, validates every requested SKU through its parent product ownership, and only allows SKUs whose parent product is exactly `MODERATED` and not deleted. Invoice creation stores a document with `status=CREATED`, requested item quantities, and `accepted_quantity=null`; it does not change `active_quantity`, `reserved_quantity`, or accepted stock.
 
-Added migration `0007_add_pending_invoice_creation_fields.py` to reuse the existing invoice tables while adding `PENDING`, `invoices.seller_id`, and nullable `invoice_items.accepted_quantity`.
+Added migration `0007_add_pending_invoice_creation_fields.py` to reuse the existing invoice tables while adding `invoices.seller_id` and nullable `invoice_items.accepted_quantity`.
 
-Local flow/b2b.yaml uses /api/invoices and older invoice status values, while the canonical flow and assignment require POST /api/v1/invoices and invoice status PENDING. This implementation follows the canonical flow and assignment endpoint.
+US-B2B-06 is migrated to the final authoritative `flow/openapi.yaml` contract; this invoice contract matches the previously reviewed `flow/neomarket-b2b.yaml` contract for the affected create/accept endpoints. `POST /api/v1/invoices` creates invoices in `CREATED`, and `POST /api/v1/invoices/{invoice_id}/accept` is the canonical accept route. The existing `POST /api/v1/invoices/accept` route remains available for compatibility and delegates to the same accept service. No US-B2B-07+ invoice behavior is included.
 
 # US-B2B-06 Validation
 
@@ -306,11 +306,23 @@ Required scenario results:
 - `test_empty_items_returns_400`: passed
 - `test_non_moderated_sku_returns_400`: passed
 - `test_others_sku_returns_403`: passed
+- `test_accept_invoice_path_alias_accepts_invoice`: passed
+- `test_legacy_accept_route_still_works`: passed
 
 Suite results:
 
-- Required US-B2B-06 scenarios: 4 passed
-- `tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py`: 32 passed
+- `tests/api/test_invoices.py`: 8 passed
+- `tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py`: 45 passed
+
+# ADR: Invoice OpenAPI Alignment
+
+Options considered:
+
+- Keep invoice creation at `PENDING` and only add the new route: minimal code change, but conflicts with the authoritative `flow/openapi.yaml` status enum and create summary.
+- Rename the legacy accept route only: aligns the URL, but would break existing callers that already use `POST /api/v1/invoices/accept`.
+- Use `CREATED` on create, add the canonical path accept route, and keep the legacy route as an alias: matches the final authoritative `flow/openapi.yaml` contract and the previously reviewed `flow/neomarket-b2b.yaml` invoice contract while preserving compatibility.
+
+Decision: treat `flow/openapi.yaml` as authoritative for US-B2B-06, with the affected invoice create/accept endpoints matching the previously reviewed `flow/neomarket-b2b.yaml` contract. New invoices are created in `CREATED`, `POST /api/v1/invoices/{invoice_id}/accept` is the canonical route, and the old body-based accept route remains as a compatibility alias to the same service function. Partial acceptance, `accepted_items`, list/get/delete, and other US-B2B-07+ invoice behavior remain out of scope.
 
 # ADR: Invoice Creation Validation Layer
 

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -276,3 +276,48 @@ Options considered:
 - Use a single route with an auth-mode dependency and separate response schemas: keeps the path aligned with the authoritative detail contract while limiting the change to product detail and reducing leakage risk through schema separation.
 
 Decision: use a single `GET /api/v1/products/{id}` route with explicit auth-mode detection. `X-Service-Key` takes precedence when present, invalid service keys fail closed, and seller JWT handling is preserved for the no-service-key path. Seller and public modes use separate service lookups and separate response schemas so seller-only fields are not serialized in public mode.
+
+---
+
+# US-B2B-06 Summary
+
+Implemented seller-facing `POST /api/v1/invoices` for inbound product supply invoices.
+
+This PR is stacked on top of US-B2B-01, US-B2B-02, US-B2B-03, US-B2B-04, and US-B2B-05 until they are merged into dev.
+
+The endpoint authenticates the seller from Bearer JWT claims, ignores any body `seller_id`/`sellerId`, validates every requested SKU through its parent product ownership, and only allows SKUs whose parent product is exactly `MODERATED` and not deleted. Invoice creation stores a document with `status=PENDING`, requested item quantities, and `accepted_quantity=null`; it does not change `active_quantity`, `reserved_quantity`, or accepted stock.
+
+Added migration `0007_add_pending_invoice_creation_fields.py` to reuse the existing invoice tables while adding `PENDING`, `invoices.seller_id`, and nullable `invoice_items.accepted_quantity`.
+
+Local flow/b2b.yaml uses /api/invoices and older invoice status values, while the canonical flow and assignment require POST /api/v1/invoices and invoice status PENDING. This implementation follows the canonical flow and assignment endpoint.
+
+# US-B2B-06 Validation
+
+Pytest proof commands:
+
+```powershell
+python -m pytest tests/api/test_invoices.py -vv -k "create_invoice_with_moderated_sku_returns_201 or empty_items_returns_400 or non_moderated_sku_returns_400 or others_sku_returns_403"
+python -m pytest tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py -vv
+```
+
+Required scenario results:
+
+- `test_create_invoice_with_moderated_sku_returns_201`: passed
+- `test_empty_items_returns_400`: passed
+- `test_non_moderated_sku_returns_400`: passed
+- `test_others_sku_returns_403`: passed
+
+Suite results:
+
+- Required US-B2B-06 scenarios: 4 passed
+- `tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py`: 32 passed
+
+# ADR: Invoice Creation Validation Layer
+
+Options considered:
+
+- Serializer/schema validation: most readable for structural payload checks such as missing `items`, but a poor fit for DB-backed SKU ownership and product status checks. Future non-HTTP callers could bypass the rule.
+- Route/view validation: readable in one endpoint, but future invoice API paths could accidentally skip ownership/status checks by calling lower-level creation logic directly.
+- Service/model layer validation: keeps ownership, deleted-product, and `MODERATED` status checks next to the invoice write. It has slightly more service code, but the lowest risk of bypass when future API paths are added.
+
+Decision: validate SKU ownership and product eligibility in the service/model layer, with route-local payload parsing only where needed to return canonical `code`/`message` errors instead of FastAPI `422`.

--- a/migrations/versions/0007_add_pending_invoice_creation_fields.py
+++ b/migrations/versions/0007_add_pending_invoice_creation_fields.py
@@ -1,0 +1,36 @@
+"""Add pending invoice creation fields."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0007_add_pending_invoice_creation_fields"
+down_revision = "0006_add_product_blocking_fields"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("ALTER TYPE invoice_status ADD VALUE IF NOT EXISTS 'PENDING'")
+
+    op.add_column(
+        "invoices",
+        sa.Column(
+            "seller_id",
+            sa.String(length=36),
+            nullable=False,
+            server_default="00000000-0000-0000-0000-000000000000",
+        ),
+    )
+    op.alter_column("invoices", "seller_id", server_default=None)
+    op.alter_column("invoices", "status", server_default=sa.text("'PENDING'"))
+    op.add_column("invoice_items", sa.Column("accepted_quantity", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("invoice_items", "accepted_quantity")
+    op.alter_column("invoices", "status", server_default=sa.text("'CREATED'"))
+    op.drop_column("invoices", "seller_id")

--- a/migrations/versions/0007_add_pending_invoice_creation_fields.py
+++ b/migrations/versions/0007_add_pending_invoice_creation_fields.py
@@ -1,4 +1,4 @@
-"""Add pending invoice creation fields."""
+"""Add invoice creation fields."""
 
 from __future__ import annotations
 
@@ -13,9 +13,6 @@ depends_on = None
 
 
 def upgrade() -> None:
-    with op.get_context().autocommit_block():
-        op.execute("ALTER TYPE invoice_status ADD VALUE IF NOT EXISTS 'PENDING'")
-
     op.add_column(
         "invoices",
         sa.Column(
@@ -26,7 +23,6 @@ def upgrade() -> None:
         ),
     )
     op.alter_column("invoices", "seller_id", server_default=None)
-    op.alter_column("invoices", "status", server_default=sa.text("'PENDING'"))
     op.add_column("invoice_items", sa.Column("accepted_quantity", sa.Integer(), nullable=True))
 
 

--- a/src/api/routes/invoices.py
+++ b/src/api/routes/invoices.py
@@ -1,16 +1,69 @@
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, Request, status
+from fastapi.responses import JSONResponse
+from pydantic import ValidationError as PydanticValidationError
 from sqlalchemy.orm import Session
 
+from src.api.deps import CurrentSeller, get_current_seller
 from src.db.session import get_db
-from src.schemas.invoice import InvoiceAccept, InvoiceCreate, InvoiceRead
-from src.services.invoice_service import accept_invoice, create_invoice
+from src.schemas.invoice import InvoiceAccept, InvoiceCreate, InvoiceCreateRead, InvoiceRead
+from src.services.errors import NotFoundError, ValidationError
+from src.services.invoice_service import InvoiceOwnerError, accept_invoice, create_invoice
 
 router = APIRouter(prefix="/api/v1/invoices", tags=["Invoices"])
 
 
-@router.post("", response_model=InvoiceRead, status_code=status.HTTP_201_CREATED)
-def create_invoice_endpoint(payload: InvoiceCreate, db: Session = Depends(get_db)) -> InvoiceRead:
-    return create_invoice(db, payload)
+def _error(status_code: int, code: str, message: str) -> JSONResponse:
+    return JSONResponse(status_code=status_code, content={"code": code, "message": message})
+
+
+def _invalid_request(message: str) -> JSONResponse:
+    return _error(400, "INVALID_REQUEST", message)
+
+
+async def _parse_invoice_create_payload(request: Request) -> InvoiceCreate | JSONResponse:
+    try:
+        body = await request.json()
+    except ValueError:
+        return _invalid_request("Invalid JSON body")
+
+    if not isinstance(body, dict):
+        return _invalid_request("Invalid invoice payload")
+
+    payload_data = dict(body)
+    payload_data.pop("seller_id", None)
+    payload_data.pop("sellerId", None)
+
+    items = payload_data.get("items")
+    if not items:
+        return _invalid_request("At least one item is required")
+
+    try:
+        return InvoiceCreate.model_validate(payload_data)
+    except PydanticValidationError:
+        return _invalid_request("Invalid invoice payload")
+
+
+@router.post("", response_model=InvoiceCreateRead, status_code=status.HTTP_201_CREATED)
+async def create_invoice_endpoint(
+    request: Request,
+    current_seller: CurrentSeller | JSONResponse = Depends(get_current_seller),
+    db: Session = Depends(get_db),
+) -> InvoiceCreateRead | JSONResponse:
+    if isinstance(current_seller, JSONResponse):
+        return current_seller
+
+    payload = await _parse_invoice_create_payload(request)
+    if isinstance(payload, JSONResponse):
+        return payload
+
+    try:
+        return create_invoice(db, payload, current_seller.seller_id)
+    except ValidationError as exc:
+        return _invalid_request(str(exc))
+    except NotFoundError:
+        return _error(404, "NOT_FOUND", "SKU not found")
+    except InvoiceOwnerError as exc:
+        return _error(403, "NOT_OWNER", str(exc))
 
 
 @router.post("/accept", response_model=InvoiceRead, status_code=status.HTTP_200_OK)

--- a/src/api/routes/invoices.py
+++ b/src/api/routes/invoices.py
@@ -69,3 +69,8 @@ async def create_invoice_endpoint(
 @router.post("/accept", response_model=InvoiceRead, status_code=status.HTTP_200_OK)
 def accept_invoice_endpoint(payload: InvoiceAccept, db: Session = Depends(get_db)) -> InvoiceRead:
     return accept_invoice(db, payload.invoice_id)
+
+
+@router.post("/{invoice_id}/accept", response_model=InvoiceRead, status_code=status.HTTP_200_OK)
+def accept_invoice_path_endpoint(invoice_id: int, db: Session = Depends(get_db)) -> InvoiceRead:
+    return accept_invoice(db, invoice_id)

--- a/src/models/invoice.py
+++ b/src/models/invoice.py
@@ -10,6 +10,7 @@ from src.models.base import Base
 
 
 class InvoiceStatus(str, Enum):
+    PENDING = "PENDING"
     CREATED = "CREATED"
     ACCEPTED = "ACCEPTED"
 
@@ -19,10 +20,11 @@ class Invoice(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     reference: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    seller_id: Mapped[str] = mapped_column(String(36), nullable=False)
     status: Mapped[InvoiceStatus] = mapped_column(
         SqlEnum(InvoiceStatus, name="invoice_status"),
         nullable=False,
-        default=InvoiceStatus.CREATED,
+        default=InvoiceStatus.PENDING,
     )
     accepted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
@@ -47,6 +49,11 @@ class InvoiceItem(Base):
     invoice_id: Mapped[int] = mapped_column(ForeignKey("invoices.id", ondelete="CASCADE"))
     sku_id: Mapped[uuid.UUID] = mapped_column(GUID(), ForeignKey("skus.id", ondelete="RESTRICT"))
     quantity: Mapped[int] = mapped_column(Integer, nullable=False)
+    accepted_quantity: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
     invoice = relationship("Invoice", back_populates="items")
     sku = relationship("SKU", back_populates="invoice_items")
+
+    @property
+    def sku_name(self) -> str:
+        return self.sku.name

--- a/src/models/invoice.py
+++ b/src/models/invoice.py
@@ -10,7 +10,6 @@ from src.models.base import Base
 
 
 class InvoiceStatus(str, Enum):
-    PENDING = "PENDING"
     CREATED = "CREATED"
     ACCEPTED = "ACCEPTED"
 
@@ -24,7 +23,7 @@ class Invoice(Base):
     status: Mapped[InvoiceStatus] = mapped_column(
         SqlEnum(InvoiceStatus, name="invoice_status"),
         nullable=False,
-        default=InvoiceStatus.PENDING,
+        default=InvoiceStatus.CREATED,
     )
     accepted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(

--- a/src/schemas/invoice.py
+++ b/src/schemas/invoice.py
@@ -8,7 +8,7 @@ from src.schemas.common import APIModel
 
 class InvoiceItemCreate(APIModel):
     sku_id: uuid.UUID = Field(validation_alias=AliasChoices("sku_id", "skuId"))
-    quantity: int = Field(gt=0)
+    quantity: int
 
 
 class InvoiceCreate(APIModel):
@@ -33,3 +33,17 @@ class InvoiceRead(APIModel):
     created_at: datetime = Field(serialization_alias="createdAt")
     items: list[InvoiceItemRead]
 
+
+class InvoiceCreateItemRead(APIModel):
+    sku_id: uuid.UUID
+    sku_name: str
+    quantity: int
+    accepted_quantity: int | None = None
+
+
+class InvoiceCreateRead(APIModel):
+    id: int
+    seller_id: str
+    status: str
+    created_at: datetime
+    items: list[InvoiceCreateItemRead]

--- a/src/services/invoice_service.py
+++ b/src/services/invoice_service.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+import uuid
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session, selectinload
@@ -23,7 +24,7 @@ def _get_invoice_or_raise(db: Session, invoice_id: int) -> Invoice:
     return invoice
 
 
-def create_invoice(db: Session, payload: InvoiceCreate, seller_id: str) -> Invoice:
+def create_invoice(db: Session, payload: InvoiceCreate, seller_id: uuid.UUID) -> Invoice:
     if not payload.items:
         raise ValidationError("At least one item is required")
     for item in payload.items:
@@ -49,7 +50,7 @@ def create_invoice(db: Session, payload: InvoiceCreate, seller_id: str) -> Invoi
         if product.deleted or product.status != ProductStatus.MODERATED:
             raise ValidationError("Invoice can only be created for MODERATED products")
 
-    invoice = Invoice(reference=payload.reference, seller_id=seller_id, status=InvoiceStatus.CREATED)
+    invoice = Invoice(reference=payload.reference, seller_id=str(seller_id), status=InvoiceStatus.CREATED)
     invoice.items = [InvoiceItem(sku_id=item.sku_id, quantity=item.quantity) for item in payload.items]
 
     db.add(invoice)

--- a/src/services/invoice_service.py
+++ b/src/services/invoice_service.py
@@ -3,13 +3,17 @@ from datetime import datetime, timezone
 from sqlalchemy import select
 from sqlalchemy.orm import Session, selectinload
 
-from src.models import Invoice, InvoiceItem, InvoiceStatus, SKU
+from src.models import Invoice, InvoiceItem, InvoiceStatus, ProductStatus, SKU
 from src.schemas.invoice import InvoiceCreate
 from src.services.errors import ConflictError, NotFoundError, ValidationError
 
 
+class InvoiceOwnerError(Exception):
+    pass
+
+
 def _invoice_query():
-    return select(Invoice).options(selectinload(Invoice.items))
+    return select(Invoice).options(selectinload(Invoice.items).selectinload(InvoiceItem.sku))
 
 
 def _get_invoice_or_raise(db: Session, invoice_id: int) -> Invoice:
@@ -19,22 +23,33 @@ def _get_invoice_or_raise(db: Session, invoice_id: int) -> Invoice:
     return invoice
 
 
-def create_invoice(db: Session, payload: InvoiceCreate) -> Invoice:
+def create_invoice(db: Session, payload: InvoiceCreate, seller_id: str) -> Invoice:
     if not payload.items:
-        raise ValidationError("Invoice must contain at least one item")
+        raise ValidationError("At least one item is required")
+    for item in payload.items:
+        if item.quantity <= 0:
+            raise ValidationError("quantity must be > 0")
 
     requested_sku_ids = [item.sku_id for item in payload.items]
     unique_sku_ids = set(requested_sku_ids)
-    if len(unique_sku_ids) != len(requested_sku_ids):
-        raise ValidationError("Invoice items must contain unique skuId values")
-
-    skus = db.scalars(select(SKU).where(SKU.id.in_(unique_sku_ids))).all()
+    skus = db.scalars(
+        select(SKU)
+        .options(selectinload(SKU.product))
+        .where(SKU.id.in_(unique_sku_ids))
+    ).all()
     if len(skus) != len(unique_sku_ids):
-        found_ids = {sku.id for sku in skus}
-        missing_ids = sorted(unique_sku_ids - found_ids)
-        raise NotFoundError(f"SKU not found: {missing_ids}")
+        raise NotFoundError("SKU not found")
 
-    invoice = Invoice(reference=payload.reference)
+    sku_map = {sku.id: sku for sku in skus}
+    for item in payload.items:
+        sku = sku_map[item.sku_id]
+        product = sku.product
+        if product.seller_id != seller_id:
+            raise InvoiceOwnerError("One or more SKUs do not belong to the authenticated seller")
+        if product.deleted or product.status != ProductStatus.MODERATED:
+            raise ValidationError("Invoice can only be created for MODERATED products")
+
+    invoice = Invoice(reference=payload.reference, seller_id=seller_id, status=InvoiceStatus.PENDING)
     invoice.items = [InvoiceItem(sku_id=item.sku_id, quantity=item.quantity) for item in payload.items]
 
     db.add(invoice)

--- a/src/services/invoice_service.py
+++ b/src/services/invoice_service.py
@@ -49,7 +49,7 @@ def create_invoice(db: Session, payload: InvoiceCreate, seller_id: str) -> Invoi
         if product.deleted or product.status != ProductStatus.MODERATED:
             raise ValidationError("Invoice can only be created for MODERATED products")
 
-    invoice = Invoice(reference=payload.reference, seller_id=seller_id, status=InvoiceStatus.PENDING)
+    invoice = Invoice(reference=payload.reference, seller_id=seller_id, status=InvoiceStatus.CREATED)
     invoice.items = [InvoiceItem(sku_id=item.sku_id, quantity=item.quantity) for item in payload.items]
 
     db.add(invoice)

--- a/tests/api/test_invoices.py
+++ b/tests/api/test_invoices.py
@@ -1,0 +1,273 @@
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from src.models import Invoice, InvoiceItem, Product, ProductImage, ProductStatus, SKU
+
+
+SELLER_ID = "c3d4e5f6-a7b8-9012-cdef-123456789012"
+OTHER_SELLER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+
+
+def create_product(
+    db_session: Session,
+    category_factory,
+    *,
+    seller_id: str = SELLER_ID,
+    status: ProductStatus = ProductStatus.MODERATED,
+    deleted: bool = False,
+) -> Product:
+    category = category_factory()
+    product = Product(
+        title="iPhone 15 Pro Max",
+        description="Flagship smartphone",
+        seller_id=seller_id,
+        category_id=category.id,
+        status=status,
+        deleted=deleted,
+    )
+    product.images = [ProductImage(url="/s3/iphone15-front.jpg", ordering=0)]
+    db_session.add(product)
+    db_session.commit()
+    db_session.refresh(product)
+    return product
+
+
+def create_sku(
+    db_session: Session,
+    product: Product,
+    *,
+    name: str = "128GB Black",
+    active_quantity: int = 0,
+    reserved_quantity: int = 0,
+) -> SKU:
+    sku = SKU(
+        product_id=product.id,
+        name=name,
+        price=9999000,
+        cost_price=7000000,
+        discount=0,
+        image="/s3/iphone15-black-128.jpg",
+        active_quantity=active_quantity,
+        reserved_quantity=reserved_quantity,
+    )
+    db_session.add(sku)
+    db_session.commit()
+    db_session.refresh(sku)
+    return sku
+
+
+def invoice_count(db_session: Session) -> int:
+    return db_session.scalar(select(func.count(Invoice.id))) or 0
+
+
+def invoice_item_count(db_session: Session) -> int:
+    return db_session.scalar(select(func.count(InvoiceItem.id))) or 0
+
+
+def test_create_invoice_with_moderated_sku_returns_201(
+    client,
+    db_session: Session,
+    category_factory,
+    auth_headers,
+):
+    product = create_product(db_session, category_factory, status=ProductStatus.MODERATED)
+    sku = create_sku(db_session, product, active_quantity=17, reserved_quantity=3)
+
+    response = client.post(
+        "/api/v1/invoices",
+        json={
+            "seller_id": OTHER_SELLER_ID,
+            "items": [{"sku_id": sku.id, "quantity": 10}],
+        },
+        headers=auth_headers(SELLER_ID),
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["seller_id"] == SELLER_ID
+    assert body["seller_id"] != OTHER_SELLER_ID
+    assert body["status"] == "PENDING"
+    assert "created_at" in body
+    assert body["items"] == [
+        {
+            "sku_id": sku.id,
+            "sku_name": "128GB Black",
+            "quantity": 10,
+            "accepted_quantity": None,
+        }
+    ]
+
+    db_session.expire_all()
+    persisted_invoice = db_session.get(Invoice, body["id"])
+    persisted_sku = db_session.get(SKU, sku.id)
+    assert persisted_invoice is not None
+    assert persisted_invoice.seller_id == SELLER_ID
+    assert persisted_invoice.status == "PENDING"
+    assert len(persisted_invoice.items) == 1
+    assert persisted_invoice.items[0].quantity == 10
+    assert persisted_invoice.items[0].accepted_quantity is None
+    assert persisted_sku.active_quantity == 17
+    assert persisted_sku.reserved_quantity == 3
+
+
+def test_empty_items_returns_400(client, db_session: Session, auth_headers):
+    response = client.post("/api/v1/invoices", json={}, headers=auth_headers(SELLER_ID))
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "code": "INVALID_REQUEST",
+        "message": "At least one item is required",
+    }
+    assert invoice_count(db_session) == 0
+    assert invoice_item_count(db_session) == 0
+
+    response = client.post("/api/v1/invoices", json={"items": []}, headers=auth_headers(SELLER_ID))
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "code": "INVALID_REQUEST",
+        "message": "At least one item is required",
+    }
+    assert invoice_count(db_session) == 0
+    assert invoice_item_count(db_session) == 0
+
+
+def test_non_moderated_sku_returns_400(
+    client,
+    db_session: Session,
+    category_factory,
+    auth_headers,
+):
+    invalid_statuses = [
+        ProductStatus.CREATED,
+        ProductStatus.ON_MODERATION,
+        ProductStatus.BLOCKED,
+        ProductStatus.HARD_BLOCKED,
+    ]
+
+    for status in invalid_statuses:
+        product = create_product(db_session, category_factory, status=status)
+        sku = create_sku(db_session, product)
+
+        response = client.post(
+            "/api/v1/invoices",
+            json={"items": [{"sku_id": sku.id, "quantity": 10}]},
+            headers=auth_headers(SELLER_ID),
+        )
+
+        assert response.status_code == 400
+        assert response.json() == {
+            "code": "INVALID_REQUEST",
+            "message": "Invoice can only be created for MODERATED products",
+        }
+
+    deleted_product = create_product(
+        db_session,
+        category_factory,
+        status=ProductStatus.MODERATED,
+        deleted=True,
+    )
+    deleted_sku = create_sku(db_session, deleted_product)
+    response = client.post(
+        "/api/v1/invoices",
+        json={"items": [{"sku_id": deleted_sku.id, "quantity": 10}]},
+        headers=auth_headers(SELLER_ID),
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "code": "INVALID_REQUEST",
+        "message": "Invoice can only be created for MODERATED products",
+    }
+    assert invoice_count(db_session) == 0
+    assert invoice_item_count(db_session) == 0
+
+
+def test_others_sku_returns_403(
+    client,
+    db_session: Session,
+    category_factory,
+    auth_headers,
+):
+    product = create_product(db_session, category_factory, seller_id=SELLER_ID)
+    sku = create_sku(db_session, product, active_quantity=5, reserved_quantity=2)
+
+    response = client.post(
+        "/api/v1/invoices",
+        json={
+            "seller_id": SELLER_ID,
+            "items": [{"sku_id": sku.id, "quantity": 10}],
+        },
+        headers=auth_headers(OTHER_SELLER_ID),
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {
+        "code": "NOT_OWNER",
+        "message": "One or more SKUs do not belong to the authenticated seller",
+    }
+    assert invoice_count(db_session) == 0
+    assert invoice_item_count(db_session) == 0
+
+    db_session.refresh(sku)
+    assert sku.active_quantity == 5
+    assert sku.reserved_quantity == 2
+
+
+def test_quantity_must_be_positive_returns_400(
+    client,
+    db_session: Session,
+    category_factory,
+    auth_headers,
+):
+    product = create_product(db_session, category_factory, status=ProductStatus.MODERATED)
+    sku = create_sku(db_session, product)
+
+    response = client.post(
+        "/api/v1/invoices",
+        json={"items": [{"sku_id": sku.id, "quantity": 0}]},
+        headers=auth_headers(SELLER_ID),
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "code": "INVALID_REQUEST",
+        "message": "quantity must be > 0",
+    }
+    assert invoice_count(db_session) == 0
+    assert invoice_item_count(db_session) == 0
+
+
+def test_invalid_mixed_items_do_not_create_partial_invoice(
+    client,
+    db_session: Session,
+    category_factory,
+    auth_headers,
+):
+    valid_product = create_product(db_session, category_factory, status=ProductStatus.MODERATED)
+    valid_sku = create_sku(db_session, valid_product, active_quantity=8, reserved_quantity=1)
+    invalid_product = create_product(db_session, category_factory, status=ProductStatus.CREATED)
+    invalid_sku = create_sku(db_session, invalid_product)
+
+    response = client.post(
+        "/api/v1/invoices",
+        json={
+            "items": [
+                {"sku_id": valid_sku.id, "quantity": 4},
+                {"sku_id": invalid_sku.id, "quantity": 2},
+            ]
+        },
+        headers=auth_headers(SELLER_ID),
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "code": "INVALID_REQUEST",
+        "message": "Invoice can only be created for MODERATED products",
+    }
+    assert invoice_count(db_session) == 0
+    assert invoice_item_count(db_session) == 0
+
+    db_session.refresh(valid_sku)
+    assert valid_sku.active_quantity == 8
+    assert valid_sku.reserved_quantity == 1

--- a/tests/api/test_invoices.py
+++ b/tests/api/test_invoices.py
@@ -86,7 +86,7 @@ def test_create_invoice_with_moderated_sku_returns_201(
     body = response.json()
     assert body["seller_id"] == SELLER_ID
     assert body["seller_id"] != OTHER_SELLER_ID
-    assert body["status"] == "PENDING"
+    assert body["status"] == "CREATED"
     assert "created_at" in body
     assert body["items"] == [
         {
@@ -102,7 +102,7 @@ def test_create_invoice_with_moderated_sku_returns_201(
     persisted_sku = db_session.get(SKU, sku.id)
     assert persisted_invoice is not None
     assert persisted_invoice.seller_id == SELLER_ID
-    assert persisted_invoice.status == "PENDING"
+    assert persisted_invoice.status == "CREATED"
     assert len(persisted_invoice.items) == 1
     assert persisted_invoice.items[0].quantity == 10
     assert persisted_invoice.items[0].accepted_quantity is None
@@ -271,3 +271,66 @@ def test_invalid_mixed_items_do_not_create_partial_invoice(
     db_session.refresh(valid_sku)
     assert valid_sku.active_quantity == 8
     assert valid_sku.reserved_quantity == 1
+
+
+def test_accept_invoice_path_alias_accepts_invoice(
+    client,
+    db_session: Session,
+    category_factory,
+    auth_headers,
+):
+    product = create_product(db_session, category_factory, status=ProductStatus.MODERATED)
+    sku = create_sku(db_session, product, active_quantity=4, reserved_quantity=1)
+    create_response = client.post(
+        "/api/v1/invoices",
+        json={"items": [{"sku_id": sku.id, "quantity": 6}]},
+        headers=auth_headers(SELLER_ID),
+    )
+    invoice_id = create_response.json()["id"]
+
+    response = client.post(f"/api/v1/invoices/{invoice_id}/accept")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == invoice_id
+    assert body["status"] == "ACCEPTED"
+    assert body["items"] == [{"skuId": sku.id, "quantity": 6}]
+
+    db_session.expire_all()
+    persisted_invoice = db_session.get(Invoice, invoice_id)
+    persisted_sku = db_session.get(SKU, sku.id)
+    assert persisted_invoice is not None
+    assert persisted_invoice.status == "ACCEPTED"
+    assert persisted_invoice.accepted_at is not None
+    assert persisted_sku.active_quantity == 10
+    assert persisted_sku.reserved_quantity == 1
+
+
+def test_legacy_accept_route_still_works(
+    client,
+    db_session: Session,
+    category_factory,
+    auth_headers,
+):
+    product = create_product(db_session, category_factory, status=ProductStatus.MODERATED)
+    sku = create_sku(db_session, product, active_quantity=2, reserved_quantity=0)
+    create_response = client.post(
+        "/api/v1/invoices",
+        json={"items": [{"sku_id": sku.id, "quantity": 3}]},
+        headers=auth_headers(SELLER_ID),
+    )
+    invoice_id = create_response.json()["id"]
+
+    response = client.post("/api/v1/invoices/accept", json={"invoice_id": invoice_id})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == invoice_id
+    assert body["status"] == "ACCEPTED"
+
+    db_session.expire_all()
+    persisted_invoice = db_session.get(Invoice, invoice_id)
+    persisted_sku = db_session.get(SKU, sku.id)
+    assert persisted_invoice is not None
+    assert persisted_invoice.status == "ACCEPTED"
+    assert persisted_sku.active_quantity == 5

--- a/tests/api/test_invoices.py
+++ b/tests/api/test_invoices.py
@@ -64,6 +64,10 @@ def invoice_item_count(db_session: Session) -> int:
     return db_session.scalar(select(func.count(InvoiceItem.id))) or 0
 
 
+def sku_item(sku: SKU, quantity: int) -> dict[str, object]:
+    return {"sku_id": str(sku.id), "quantity": quantity}
+
+
 def test_create_invoice_with_moderated_sku_returns_201(
     client,
     db_session: Session,
@@ -77,7 +81,7 @@ def test_create_invoice_with_moderated_sku_returns_201(
         "/api/v1/invoices",
         json={
             "seller_id": OTHER_SELLER_ID,
-            "items": [{"sku_id": sku.id, "quantity": 10}],
+            "items": [sku_item(sku, 10)],
         },
         headers=auth_headers(SELLER_ID),
     )
@@ -90,7 +94,7 @@ def test_create_invoice_with_moderated_sku_returns_201(
     assert "created_at" in body
     assert body["items"] == [
         {
-            "sku_id": sku.id,
+            "sku_id": str(sku.id),
             "sku_name": "128GB Black",
             "quantity": 10,
             "accepted_quantity": None,
@@ -151,7 +155,7 @@ def test_non_moderated_sku_returns_400(
 
         response = client.post(
             "/api/v1/invoices",
-            json={"items": [{"sku_id": sku.id, "quantity": 10}]},
+            json={"items": [sku_item(sku, 10)]},
             headers=auth_headers(SELLER_ID),
         )
 
@@ -170,7 +174,7 @@ def test_non_moderated_sku_returns_400(
     deleted_sku = create_sku(db_session, deleted_product)
     response = client.post(
         "/api/v1/invoices",
-        json={"items": [{"sku_id": deleted_sku.id, "quantity": 10}]},
+        json={"items": [sku_item(deleted_sku, 10)]},
         headers=auth_headers(SELLER_ID),
     )
 
@@ -196,7 +200,7 @@ def test_others_sku_returns_403(
         "/api/v1/invoices",
         json={
             "seller_id": SELLER_ID,
-            "items": [{"sku_id": sku.id, "quantity": 10}],
+            "items": [sku_item(sku, 10)],
         },
         headers=auth_headers(OTHER_SELLER_ID),
     )
@@ -225,7 +229,7 @@ def test_quantity_must_be_positive_returns_400(
 
     response = client.post(
         "/api/v1/invoices",
-        json={"items": [{"sku_id": sku.id, "quantity": 0}]},
+        json={"items": [sku_item(sku, 0)]},
         headers=auth_headers(SELLER_ID),
     )
 
@@ -253,8 +257,8 @@ def test_invalid_mixed_items_do_not_create_partial_invoice(
         "/api/v1/invoices",
         json={
             "items": [
-                {"sku_id": valid_sku.id, "quantity": 4},
-                {"sku_id": invalid_sku.id, "quantity": 2},
+                sku_item(valid_sku, 4),
+                sku_item(invalid_sku, 2),
             ]
         },
         headers=auth_headers(SELLER_ID),
@@ -283,7 +287,7 @@ def test_accept_invoice_path_alias_accepts_invoice(
     sku = create_sku(db_session, product, active_quantity=4, reserved_quantity=1)
     create_response = client.post(
         "/api/v1/invoices",
-        json={"items": [{"sku_id": sku.id, "quantity": 6}]},
+        json={"items": [sku_item(sku, 6)]},
         headers=auth_headers(SELLER_ID),
     )
     invoice_id = create_response.json()["id"]
@@ -294,7 +298,7 @@ def test_accept_invoice_path_alias_accepts_invoice(
     body = response.json()
     assert body["id"] == invoice_id
     assert body["status"] == "ACCEPTED"
-    assert body["items"] == [{"skuId": sku.id, "quantity": 6}]
+    assert body["items"] == [{"skuId": str(sku.id), "quantity": 6}]
 
     db_session.expire_all()
     persisted_invoice = db_session.get(Invoice, invoice_id)
@@ -316,7 +320,7 @@ def test_legacy_accept_route_still_works(
     sku = create_sku(db_session, product, active_quantity=2, reserved_quantity=0)
     create_response = client.post(
         "/api/v1/invoices",
-        json={"items": [{"sku_id": sku.id, "quantity": 3}]},
+        json={"items": [sku_item(sku, 3)]},
         headers=auth_headers(SELLER_ID),
     )
     invoice_id = create_response.json()["id"]


### PR DESCRIPTION
# US-B2B-06 Summary

Implemented seller-facing `POST /api/v1/invoices` for inbound product supply invoices.

This PR is stacked on top of US-B2B-01, US-B2B-02, US-B2B-03, US-B2B-04, and US-B2B-05 until they are merged into dev.

The endpoint authenticates the seller from Bearer JWT claims, ignores any body `seller_id`/`sellerId`, validates every requested SKU through its parent product ownership, and only allows SKUs whose parent product is exactly `MODERATED` and not deleted. Invoice creation stores a document with `status=CREATED`, requested item quantities, and `accepted_quantity=null`; it does not change `active_quantity`, `reserved_quantity`, or accepted stock.

Added migration `0007_add_pending_invoice_creation_fields.py` to reuse the existing invoice tables while adding `invoices.seller_id` and nullable `invoice_items.accepted_quantity`.

US-B2B-06 is migrated to the final authoritative `flow/openapi.yaml` contract; this invoice contract matches the previously reviewed `flow/neomarket-b2b.yaml` contract for the affected create/accept endpoints. `POST /api/v1/invoices` creates invoices in `CREATED`, and `POST /api/v1/invoices/{invoice_id}/accept` is the canonical accept route. The existing `POST /api/v1/invoices/accept` route remains available for compatibility and delegates to the same accept service. No US-B2B-07+ invoice behavior is included.

# US-B2B-06 Validation

Pytest proof commands:

```powershell
python -m pytest tests/api/test_invoices.py -vv -k "create_invoice_with_moderated_sku_returns_201 or empty_items_returns_400 or non_moderated_sku_returns_400 or others_sku_returns_403"
python -m pytest tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py -vv
```

Required scenario results:

- `test_create_invoice_with_moderated_sku_returns_201`: passed
- `test_empty_items_returns_400`: passed
- `test_non_moderated_sku_returns_400`: passed
- `test_others_sku_returns_403`: passed
- `test_accept_invoice_path_alias_accepts_invoice`: passed
- `test_legacy_accept_route_still_works`: passed

Suite results:

- `tests/api/test_invoices.py`: 8 passed
- `tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py`: 45 passed

# ADR: Invoice OpenAPI Alignment

Options considered:

- Keep invoice creation at `PENDING` and only add the new route: minimal code change, but conflicts with the authoritative `flow/openapi.yaml` status enum and create summary.
- Rename the legacy accept route only: aligns the URL, but would break existing callers that already use `POST /api/v1/invoices/accept`.
- Use `CREATED` on create, add the canonical path accept route, and keep the legacy route as an alias: matches the final authoritative `flow/openapi.yaml` contract and the previously reviewed `flow/neomarket-b2b.yaml` invoice contract while preserving compatibility.

Decision: treat `flow/openapi.yaml` as authoritative for US-B2B-06, with the affected invoice create/accept endpoints matching the previously reviewed `flow/neomarket-b2b.yaml` contract. New invoices are created in `CREATED`, `POST /api/v1/invoices/{invoice_id}/accept` is the canonical route, and the old body-based accept route remains as a compatibility alias to the same service function. Partial acceptance, `accepted_items`, list/get/delete, and other US-B2B-07+ invoice behavior remain out of scope.

# ADR: Invoice Creation Validation Layer

Options considered:

- Serializer/schema validation: most readable for structural payload checks such as missing `items`, but a poor fit for DB-backed SKU ownership and product status checks. Future non-HTTP callers could bypass the rule.
- Route/view validation: readable in one endpoint, but future invoice API paths could accidentally skip ownership/status checks by calling lower-level creation logic directly.
- Service/model layer validation: keeps ownership, deleted-product, and `MODERATED` status checks next to the invoice write. It has slightly more service code, but the lowest risk of bypass when future API paths are added.

Decision: validate SKU ownership and product eligibility in the service/model layer, with route-local payload parsing only where needed to return canonical `code`/`message` errors instead of FastAPI `422`.