### PR TITLE
US-B2B-07: Implement B2C catalog mode

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -333,3 +333,49 @@ Options considered:
 - Service/model layer validation: keeps ownership, deleted-product, and `MODERATED` status checks next to the invoice write. It has slightly more service code, but the lowest risk of bypass when future API paths are added.
 
 Decision: validate SKU ownership and product eligibility in the service/model layer, with route-local payload parsing only where needed to return canonical `code`/`message` errors instead of FastAPI `422`.
+
+---
+
+# US-B2B-07 Summary
+
+Implemented B2C catalog mode for `GET /api/v1/public/products` on top of US-B2B-01 through US-B2B-06. This remains a stacked change until those earlier slices are merged.
+
+The public catalog endpoint requires `X-Service-Key`. A valid key matching `settings.b2c_to_b2b_key` uses catalog mode without JWT. An invalid or missing service key returns `401 {"code":"UNAUTHORIZED","message":"Authorization required"}`. The existing seller-list endpoint remains `GET /api/v1/products` and still requires the seller Bearer JWT. Seller JWTs are not accepted as a substitute for the B2C service key.
+
+Catalog mode returns only products with `status=MODERATED`, `deleted=false`, and at least one SKU with `active_quantity > 0`. Hidden, deleted, nonexistent, non-moderated, no-SKU, and out-of-stock products are silently omitted from both full catalog and batch responses. IDs remain UUID-backed. Batch lookup uses `POST /api/v1/public/products/batch` with `product_ids`; invalid ID tokens return `400 INVALID_REQUEST`.
+
+Catalog serialization uses dedicated allowlisted schemas. Product output includes only `id`, `title`, `description`, `status`, `category`, `images`, `characteristics`, and `skus`. SKU output includes only public SKU fields and UUID-backed `images[]`. It does not expose seller-only or moderation-only fields such as `cost_price`, `reserved_quantity`, `seller_id`, `deleted`, `blocking_reason`, or `field_reports`.
+
+Implementation follows final `flow/openapi.yaml` public catalog paths and keeps the reviewed US-B2B-07 behavior aligned with the UUID contract from US-B2B-01 through US-B2B-06.
+
+Assumption: catalog responses include only in-stock SKUs to reduce exposure of unavailable variants.
+
+# US-B2B-07 Validation
+
+Pytest proof commands:
+
+```powershell
+python -m pytest tests/api/test_products.py -vv -k "test_catalog_returns_moderated_in_stock_products or test_catalog_excludes_hard_blocked or test_catalog_missing_service_key_returns_401 or test_catalog_response_has_no_cost_price or test_batch_ids_returns_visible_subset"
+python -m pytest tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py -vv
+```
+
+Required scenario results:
+
+- `test_catalog_returns_moderated_in_stock_products`: passed
+- `test_catalog_excludes_hard_blocked`: passed
+- `test_catalog_missing_service_key_returns_401`: passed
+- `test_catalog_response_has_no_cost_price`: passed
+- `test_batch_ids_returns_visible_subset`: passed
+
+Suite results:
+
+- Required US-B2B-07 scenarios: 5 passed
+- `tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py`: 37 passed
+
+# ADR: B2C Catalog Mode Routing
+
+Options considered:
+
+- Public URL per final OpenAPI: selected. It keeps catalog routing at `/api/v1/public/products`, leaves seller-list behavior on `/api/v1/products`, and keeps field-leak risk controlled by dedicated catalog schemas and service logic.
+- One URL with branching by header: rejected for the rebased branch because final `flow/openapi.yaml` defines separate public catalog paths.
+- Two duplicate view functions on the same path: rejected because duplicate method/path registration in FastAPI is route-order dependent and increases maintenance risk.

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -44,7 +44,7 @@ The SKU endpoint authenticates the seller from JWT claims, verifies that the par
 
 После принятого UUID root fix ответ создания SKU использует UUID-backed `id` и `product_id` без stringification integer ID на границе ответа. Ответ также возвращает `article`, `images[]`, `stock_quantity`, `created_at` и `updated_at`, где текущая storage model поддерживает эти поля безопасно. Для первого SKU у продукта в статусе `CREATED` продукт переходит в `ON_MODERATION` и отправляет ровно одно событие Moderation `CREATED`. Дополнительные SKU у продуктов, которые уже находятся на модерации, не отправляют события и не меняют статус.
 
-External arbiter response-contract fix: the shared `ImageOut` and `CharacteristicOut` schemas include `id`. SKU characteristics return their persisted row ids. SKU images use a response-boundary synthetic id shaped as `sku-image:{sku.id}:0` because this codebase stores only one `skus.image` URL and has no SKU image table. No DB migration for SKU images is introduced.
+External arbiter response-contract fix: the shared `ImageOut` and `CharacteristicOut` schemas include `id`. SKU characteristics return their persisted row ids. SKU images use a deterministic response-boundary UUID generated from the seed `sku-image:{sku.id}:0` because this codebase stores only one `skus.image` URL and has no SKU image table. No DB migration for SKU images is introduced.
 
 The Moderation event is sent to `{moderation_url}/api/v1/events/product` with `X-Service-Key`. The payload includes `idempotency_key`, `product_id`, `seller_id`, `event`, and `date`. The canonical flow requires an `idempotency_key`, but does not define deterministic generation or a UUID namespace; this implementation uses a stable UUIDv5 derived from `product-created:<product_id>` with `uuid.NAMESPACE_URL`, and documents that as a local assumption.
 
@@ -237,7 +237,7 @@ When a valid `X-Service-Key` is present, the endpoint uses public B2C mode and d
 
 Seller and public detail responses preserve the accepted UUID-backed contract from US-B2B-01 and US-B2B-02: product, category, image, characteristic, and nested SKU ids are UUID values, nested SKU images are returned as `images[]`, and no integer-id response serialization is reintroduced. Public detail uses separate response schemas to omit seller-only fields, includes only in-stock public SKUs, maps public `stock_quantity` to `active_quantity`, and keeps `active_quantity` because the schema requires it.
 
-External arbiter contract fix: seller detail now includes ProductResponse-required top-level fields `slug`, `blocking_reason_id`, and `moderator_comment` while keeping the enriched `blocking_reason` and `field_reports` details for blocked products. Seller detail nested SKUs now include SKUResponse-required fields `product_id`, `stock_quantity`, `article`, `images`, `created_at`, and `updated_at` alongside seller-only `cost_price` and `reserved_quantity`. Seller SKU images are returned as `images[]` with stable synthetic response-only ids shaped as `sku-image:{sku.id}:0` because this codebase stores only one `skus.image` URL and has no SKU image table. The shared `ImageOut` and `CharacteristicOut` `id` fix is preserved, and the public view remains seller-data-safe by hiding `cost_price`, `reserved_quantity`, `blocking_reason`, and `field_reports`.
+External arbiter contract fix: seller detail now includes ProductResponse-required top-level fields `slug`, `blocking_reason_id`, and `moderator_comment` while keeping the enriched `blocking_reason` and `field_reports` details for blocked products. Seller detail nested SKUs now include SKUResponse-required fields `product_id`, `stock_quantity`, `article`, `images`, `created_at`, and `updated_at` alongside seller-only `cost_price` and `reserved_quantity`. Seller SKU images are returned as `images[]` with stable synthetic response-only UUID ids generated from the seed `sku-image:{sku.id}:0` because this codebase stores only one `skus.image` URL and has no SKU image table. The shared `ImageOut` and `CharacteristicOut` `id` fix is preserved, and the public view remains seller-data-safe by hiding `cost_price`, `reserved_quantity`, `blocking_reason`, and `field_reports`.
 
 # US-B2B-05 Validation
 
@@ -338,44 +338,66 @@ Decision: validate SKU ownership and product eligibility in the service/model la
 
 # US-B2B-07 Summary
 
-Implemented B2C catalog mode for `GET /api/v1/public/products` on top of US-B2B-01 through US-B2B-06. This remains a stacked change until those earlier slices are merged.
+US-B2B-07 is migrated to the final authoritative `flow/openapi.yaml` public catalog contract. For the affected public catalog list and batch endpoints, this contract matches the previously reviewed `neomarket-b2b.yaml` public catalog contract.
 
-The public catalog endpoint requires `X-Service-Key`. A valid key matching `settings.b2c_to_b2b_key` uses catalog mode without JWT. An invalid or missing service key returns `401 {"code":"UNAUTHORIZED","message":"Authorization required"}`. The existing seller-list endpoint remains `GET /api/v1/products` and still requires the seller Bearer JWT. Seller JWTs are not accepted as a substitute for the B2C service key.
+Migrated the B2C public catalog surface to the authoritative `flow/openapi.yaml` paths for this slice:
 
-Catalog mode returns only products with `status=MODERATED`, `deleted=false`, and at least one SKU with `active_quantity > 0`. Hidden, deleted, nonexistent, non-moderated, no-SKU, and out-of-stock products are silently omitted from both full catalog and batch responses. IDs remain UUID-backed. Batch lookup uses `POST /api/v1/public/products/batch` with `product_ids`; invalid ID tokens return `400 INVALID_REQUEST`.
+- `GET /api/v1/public/products`
+- `POST /api/v1/public/products/batch`
 
-Catalog serialization uses dedicated allowlisted schemas. Product output includes only `id`, `title`, `description`, `status`, `category`, `images`, `characteristics`, and `skus`. SKU output includes only public SKU fields and UUID-backed `images[]`. It does not expose seller-only or moderation-only fields such as `cost_price`, `reserved_quantity`, `seller_id`, `deleted`, `blocking_reason`, or `field_reports`.
+The legacy service-key catalog entrypoint `GET /api/v1/products` remains available for compatibility, while seller `GET /api/v1/products`, seller/public `GET /api/v1/products/{product_id}`, product create/edit/delete, SKU, and invoice behavior are preserved.
 
-Implementation follows final `flow/openapi.yaml` public catalog paths and keeps the reviewed US-B2B-07 behavior aligned with the UUID contract from US-B2B-01 through US-B2B-06.
+Public catalog routes require `X-Service-Key == settings.b2c_to_b2b_key`; missing or invalid service keys return `401 {"code":"UNAUTHORIZED","message":"Authorization required"}`.
 
-Assumption: catalog responses include only in-stock SKUs to reduce exposure of unavailable variants.
+Public list and batch visibility is restricted to products with `status=MODERATED`, `deleted=false`, and at least one SKU where `active_quantity > 0`. Public SKU arrays include only in-stock SKUs. Missing, hidden, deleted, non-moderated, nonexistent, and out-of-stock products are omitted from batch responses instead of failing the whole batch.
+
+Public list responses use canonical short products with `id`, `title`, `slug`, `status`, `category_id`, `min_price`, `cover_image`, and `created_at`. Public batch responses use the full public product schema. Public responses do not expose seller-only or moderation/deletion fields such as `cost_price`, `reserved_quantity`, `deleted`, `blocking_reason`, `field_reports`, `moderator_comment`, or `blocking_reason_id`. Public SKU `stock_quantity` equals `active_quantity`.
+
+Temporary compatibility note: the current database stores one SKU image URL directly on `skus.image` and has no SKU image table. Public SKU image responses therefore synthesize stable UUID response-boundary IDs using the seed `sku-image:{sku_id}:0` when a SKU image URL exists. The raw SKU ID is not reused as `images[].id`.
+
+Unsupported OpenAPI surface in this branch: `GET /api/v1/public/products` implements only `limit` and `offset`. `category_id`, `search`, price filters, seller filters, dynamic `filters`, and advanced `sort` are documented by `flow/openapi.yaml` but intentionally deferred outside US-B2B-07.
 
 # US-B2B-07 Validation
 
 Pytest proof commands:
 
 ```powershell
-python -m pytest tests/api/test_products.py -vv -k "test_catalog_returns_moderated_in_stock_products or test_catalog_excludes_hard_blocked or test_catalog_missing_service_key_returns_401 or test_catalog_response_has_no_cost_price or test_batch_ids_returns_visible_subset"
+python -m pytest tests/api/test_products.py -vv
 python -m pytest tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py -vv
 ```
 
 Required scenario results:
 
-- `test_catalog_returns_moderated_in_stock_products`: passed
-- `test_catalog_excludes_hard_blocked`: passed
-- `test_catalog_missing_service_key_returns_401`: passed
-- `test_catalog_response_has_no_cost_price`: passed
-- `test_batch_ids_returns_visible_subset`: passed
+- `test_public_catalog_returns_short_paginated_products`: passed
+- `test_public_catalog_excludes_non_moderated_deleted_and_out_of_stock`: passed
+- `test_public_catalog_requires_valid_service_key`: passed
+- `test_public_catalog_response_has_no_seller_only_fields`: passed
+- `test_public_batch_returns_visible_full_public_products`: passed
+- `test_public_batch_omits_missing_hidden_deleted_and_out_of_stock_products`: passed
+- `test_public_batch_requires_valid_service_key`: passed
+- `test_legacy_products_service_key_catalog_route_remains_supported`: passed
 
 Suite results:
 
-- Required US-B2B-07 scenarios: 5 passed
-- `tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py`: 37 passed
+- `tests/api/test_products.py`: 31 passed
+- `tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py`: 53 passed
 
-# ADR: B2C Catalog Mode Routing
+# ADR: Public Catalog Routing And Compatibility
 
 Options considered:
 
-- Public URL per final OpenAPI: selected. It keeps catalog routing at `/api/v1/public/products`, leaves seller-list behavior on `/api/v1/products`, and keeps field-leak risk controlled by dedicated catalog schemas and service logic.
-- One URL with branching by header: rejected for the rebased branch because final `flow/openapi.yaml` defines separate public catalog paths.
-- Two duplicate view functions on the same path: rejected because duplicate method/path registration in FastAPI is route-order dependent and increases maintenance risk.
+- Keep only the legacy `GET /api/v1/products` service-key mode: lowest route churn, but it leaves US-B2B-07 off the authoritative `flow/openapi.yaml` public catalog paths.
+- Move all B2C catalog traffic to `/api/v1/public/products` and remove legacy behavior: cleanest contract, but breaks existing stacked behavior and callers using the service-key route.
+- Add canonical public routes and keep the legacy service-key route as a compatibility alias: selected. This aligns new B2C catalog calls with `flow/openapi.yaml`, preserves existing seller/product behavior, and keeps field-leak risk controlled through dedicated public schemas and shared service visibility helpers.
+
+Decision: canonical list and batch live under `/api/v1/public/products`. The legacy `GET /api/v1/products` service-key branch remains as a small compatibility route returning the same short public list shape. Batch lookup is canonicalized to `POST /api/v1/public/products/batch`; old `?ids=` test coverage was removed.
+
+# ADR: Deferred Public Catalog Filters
+
+Options considered:
+
+- Implement every filter declared in `flow/openapi.yaml`: aligns the broad schema immediately, but expands this migration into search, price filtering, seller filtering, dynamic characteristic filtering, and sort behavior that are not part of the US-B2B-07 slice.
+- Reject unsupported query parameters explicitly: clearer to clients, but risks breaking forward-compatible callers that may already send no-op parameters through a gateway.
+- Implement only pagination and document the unsupported surface: selected for this branch. It keeps behavior narrow and testable while making the contract gap explicit.
+
+Decision: only `limit` and `offset` are active for `GET /api/v1/public/products` in this slice. `category_id`, `search`, `min_price`, `max_price`, `seller_id`, dynamic `filters`, and advanced `sort` remain deferred.

--- a/src/api/router.py
+++ b/src/api/router.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter
 from src.api.routes import invoices, products, skus
 
 api_router = APIRouter()
+api_router.include_router(products.public_router)
 api_router.include_router(products.router)
 api_router.include_router(skus.router)
 api_router.include_router(invoices.router)

--- a/src/api/router.py
+++ b/src/api/router.py
@@ -1,9 +1,9 @@
 from fastapi import APIRouter
 
-from src.api.routes import invoices, products, skus
+from src.api.routes import invoices, products, public_products, skus
 
 api_router = APIRouter()
-api_router.include_router(products.public_router)
+api_router.include_router(public_products.router)
 api_router.include_router(products.router)
 api_router.include_router(skus.router)
 api_router.include_router(invoices.router)

--- a/src/api/routes/products.py
+++ b/src/api/routes/products.py
@@ -1,12 +1,22 @@
 import uuid
 
-from fastapi import APIRouter, Depends, Response, status
+from fastapi import APIRouter, Depends, Header, Query, Response, status
 from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 
-from src.api.deps import CurrentSeller, ProductDetailAccess, get_current_seller, get_product_detail_access
+from src.api.deps import (
+    CurrentSeller,
+    ProductDetailAccess,
+    get_current_seller,
+    get_product_detail_access,
+    oauth2_scheme,
+    unauthorized_response,
+)
+from src.core.config import settings
 from src.db.session import get_db
 from src.schemas.product import (
+    CatalogProductListRead,
+    CatalogProductRead,
     ProductCreate,
     ProductCreateRead,
     ProductListRead,
@@ -26,11 +36,13 @@ from src.services.product_service import (
     delete_product,
     get_public_product_by_id,
     get_seller_product_by_id,
+    list_catalog_products,
     list_seller_products,
     update_product,
 )
 
 router = APIRouter(prefix="/api/v1/products", tags=["Products"])
+public_router = APIRouter(prefix="/api/v1/public/products", tags=["Public Catalog"])
 
 
 def _field_validation_error(field: str, message: str) -> JSONResponse:
@@ -46,6 +58,36 @@ def _error(status_code: int, code: str, message: str) -> JSONResponse:
 
 def _invalid_request(message: str) -> JSONResponse:
     return _error(400, "INVALID_REQUEST", message)
+
+
+def _parse_ids(raw_ids: list[str] | None) -> list[uuid.UUID] | JSONResponse | None:
+    if raw_ids is None:
+        return None
+
+    product_ids: list[uuid.UUID] = []
+    for raw_value in raw_ids:
+        for token in raw_value.split(","):
+            try:
+                product_id = uuid.UUID(token.strip())
+            except ValueError:
+                return _invalid_request("ids must be a comma-separated list of product ids")
+            product_ids.append(product_id)
+    return product_ids
+
+
+def _catalog_product(product) -> CatalogProductRead:
+    return CatalogProductRead.model_validate(
+        {
+            "id": product.id,
+            "title": product.title,
+            "description": product.description,
+            "status": product.status,
+            "category": product.category,
+            "images": product.images,
+            "characteristics": product.characteristics,
+            "skus": [sku for sku in product.skus if sku.active_quantity > 0],
+        }
+    )
 
 
 @router.post("", response_model=ProductCreateRead, status_code=status.HTTP_201_CREATED)
@@ -65,18 +107,70 @@ async def create_product_endpoint(
         return _field_validation_error(exc.field, exc.message)
 
 
+@public_router.get("", response_model=CatalogProductListRead, status_code=status.HTTP_200_OK)
+def list_public_products_endpoint(
+    limit: int = 20,
+    offset: int = 0,
+    ids: list[str] | None = Query(default=None),
+    service_key: str | None = Header(default=None, alias="X-Service-Key"),
+    db: Session = Depends(get_db),
+) -> CatalogProductListRead | JSONResponse:
+    if service_key != settings.b2c_to_b2b_key:
+        return unauthorized_response()
+
+    product_ids = _parse_ids(ids)
+    if isinstance(product_ids, JSONResponse):
+        return product_ids
+
+    bounded_limit = min(max(limit, 1), 100)
+    bounded_offset = max(offset, 0)
+    products, total_count = list_catalog_products(
+        db,
+        product_ids=product_ids,
+        limit=bounded_limit,
+        offset=bounded_offset,
+    )
+    return CatalogProductListRead(
+        items=[_catalog_product(product) for product in products],
+        total_count=total_count,
+        limit=bounded_limit,
+        offset=bounded_offset,
+    )
+
+
+@public_router.post("/batch", response_model=list[CatalogProductRead], status_code=status.HTTP_200_OK)
+def batch_public_products_endpoint(
+    payload: dict[str, list[str]],
+    service_key: str | None = Header(default=None, alias="X-Service-Key"),
+    db: Session = Depends(get_db),
+) -> list[CatalogProductRead] | JSONResponse:
+    if service_key != settings.b2c_to_b2b_key:
+        return unauthorized_response()
+
+    product_ids = _parse_ids(payload.get("product_ids"))
+    if product_ids is None:
+        product_ids = []
+    if isinstance(product_ids, JSONResponse):
+        return product_ids
+
+    products, _ = list_catalog_products(db, product_ids=product_ids)
+    return [_catalog_product(product) for product in products]
+
+
 @router.get("", response_model=ProductListRead, status_code=status.HTTP_200_OK)
 def list_products_endpoint(
     limit: int = 20,
     offset: int = 0,
-    current_seller: CurrentSeller | JSONResponse = Depends(get_current_seller),
+    token: str | None = Depends(oauth2_scheme),
     db: Session = Depends(get_db),
 ) -> ProductListRead | JSONResponse:
+    bounded_limit = min(max(limit, 1), 100)
+    bounded_offset = max(offset, 0)
+
+    current_seller = get_current_seller(token)
     if isinstance(current_seller, JSONResponse):
         return current_seller
 
-    bounded_limit = min(max(limit, 1), 100)
-    bounded_offset = max(offset, 0)
     products, total_count = list_seller_products(
         db,
         current_seller.seller_id,

--- a/src/api/routes/products.py
+++ b/src/api/routes/products.py
@@ -15,13 +15,13 @@ from src.api.deps import (
 from src.core.config import settings
 from src.db.session import get_db
 from src.schemas.product import (
-    CatalogProductListRead,
-    CatalogProductRead,
     ProductCreate,
     ProductCreateRead,
     ProductListRead,
+    ProductPublicPaginatedResponse,
     ProductPublicRead,
     ProductResponse,
+    ProductPublicShortRead,
     ProductUpdate,
     SellerProductRead,
 )
@@ -36,13 +36,13 @@ from src.services.product_service import (
     delete_product,
     get_public_product_by_id,
     get_seller_product_by_id,
-    list_catalog_products,
+    list_public_catalog_products,
+    list_public_products_by_ids,
     list_seller_products,
     update_product,
 )
 
 router = APIRouter(prefix="/api/v1/products", tags=["Products"])
-public_router = APIRouter(prefix="/api/v1/public/products", tags=["Public Catalog"])
 
 
 def _field_validation_error(field: str, message: str) -> JSONResponse:
@@ -75,21 +75,6 @@ def _parse_ids(raw_ids: list[str] | None) -> list[uuid.UUID] | JSONResponse | No
     return product_ids
 
 
-def _catalog_product(product) -> CatalogProductRead:
-    return CatalogProductRead.model_validate(
-        {
-            "id": product.id,
-            "title": product.title,
-            "description": product.description,
-            "status": product.status,
-            "category": product.category,
-            "images": product.images,
-            "characteristics": product.characteristics,
-            "skus": [sku for sku in product.skus if sku.active_quantity > 0],
-        }
-    )
-
-
 @router.post("", response_model=ProductCreateRead, status_code=status.HTTP_201_CREATED)
 async def create_product_endpoint(
     payload: ProductCreate,
@@ -107,65 +92,41 @@ async def create_product_endpoint(
         return _field_validation_error(exc.field, exc.message)
 
 
-@public_router.get("", response_model=CatalogProductListRead, status_code=status.HTTP_200_OK)
-def list_public_products_endpoint(
+@router.get("", response_model=ProductListRead | ProductPublicPaginatedResponse, status_code=status.HTTP_200_OK)
+def list_products_endpoint(
     limit: int = 20,
     offset: int = 0,
     ids: list[str] | None = Query(default=None),
     service_key: str | None = Header(default=None, alias="X-Service-Key"),
-    db: Session = Depends(get_db),
-) -> CatalogProductListRead | JSONResponse:
-    if service_key != settings.b2c_to_b2b_key:
-        return unauthorized_response()
-
-    product_ids = _parse_ids(ids)
-    if isinstance(product_ids, JSONResponse):
-        return product_ids
-
-    bounded_limit = min(max(limit, 1), 100)
-    bounded_offset = max(offset, 0)
-    products, total_count = list_catalog_products(
-        db,
-        product_ids=product_ids,
-        limit=bounded_limit,
-        offset=bounded_offset,
-    )
-    return CatalogProductListRead(
-        items=[_catalog_product(product) for product in products],
-        total_count=total_count,
-        limit=bounded_limit,
-        offset=bounded_offset,
-    )
-
-
-@public_router.post("/batch", response_model=list[CatalogProductRead], status_code=status.HTTP_200_OK)
-def batch_public_products_endpoint(
-    payload: dict[str, list[str]],
-    service_key: str | None = Header(default=None, alias="X-Service-Key"),
-    db: Session = Depends(get_db),
-) -> list[CatalogProductRead] | JSONResponse:
-    if service_key != settings.b2c_to_b2b_key:
-        return unauthorized_response()
-
-    product_ids = _parse_ids(payload.get("product_ids"))
-    if product_ids is None:
-        product_ids = []
-    if isinstance(product_ids, JSONResponse):
-        return product_ids
-
-    products, _ = list_catalog_products(db, product_ids=product_ids)
-    return [_catalog_product(product) for product in products]
-
-
-@router.get("", response_model=ProductListRead, status_code=status.HTTP_200_OK)
-def list_products_endpoint(
-    limit: int = 20,
-    offset: int = 0,
     token: str | None = Depends(oauth2_scheme),
     db: Session = Depends(get_db),
-) -> ProductListRead | JSONResponse:
+) -> ProductListRead | ProductPublicPaginatedResponse | JSONResponse:
     bounded_limit = min(max(limit, 1), 100)
     bounded_offset = max(offset, 0)
+
+    if service_key is not None:
+        if service_key != settings.b2c_to_b2b_key:
+            return unauthorized_response()
+
+        product_ids = _parse_ids(ids)
+        if isinstance(product_ids, JSONResponse):
+            return product_ids
+
+        if product_ids is None:
+            products, total_count = list_public_catalog_products(
+                db,
+                limit=bounded_limit,
+                offset=bounded_offset,
+            )
+        else:
+            products = list_public_products_by_ids(db, product_ids)
+            total_count = len(products)
+        return ProductPublicPaginatedResponse(
+            items=[ProductPublicShortRead.model_validate(product) for product in products],
+            total_count=total_count,
+            limit=bounded_limit,
+            offset=bounded_offset,
+        )
 
     current_seller = get_current_seller(token)
     if isinstance(current_seller, JSONResponse):

--- a/src/api/routes/products.py
+++ b/src/api/routes/products.py
@@ -121,12 +121,13 @@ def list_products_endpoint(
         else:
             products = list_public_products_by_ids(db, product_ids)
             total_count = len(products)
-        return ProductPublicPaginatedResponse(
+        public_response = ProductPublicPaginatedResponse(
             items=[ProductPublicShortRead.model_validate(product) for product in products],
             total_count=total_count,
             limit=bounded_limit,
             offset=bounded_offset,
         )
+        return JSONResponse(content=public_response.model_dump(mode="json"))
 
     current_seller = get_current_seller(token)
     if isinstance(current_seller, JSONResponse):

--- a/src/api/routes/public_products.py
+++ b/src/api/routes/public_products.py
@@ -1,0 +1,85 @@
+import hmac
+import uuid
+
+from fastapi import APIRouter, Depends, Header, status
+from fastapi.responses import JSONResponse
+from sqlalchemy.orm import Session
+
+from src.api.deps import unauthorized_response
+from src.core.config import settings
+from src.db.session import get_db
+from src.schemas.product import (
+    ProductPublicPaginatedResponse,
+    ProductPublicRead,
+    ProductPublicShortRead,
+    PublicProductBatchRequest,
+)
+from src.services.product_service import list_public_catalog_products, list_public_products_by_ids
+
+router = APIRouter(prefix="/api/v1/public/products", tags=["Public Catalog"])
+
+
+def require_public_service_key(
+    service_key: str | None = Header(default=None, alias="X-Service-Key"),
+) -> JSONResponse | None:
+    if service_key is None or not hmac.compare_digest(service_key, settings.b2c_to_b2b_key):
+        return unauthorized_response()
+    return None
+
+
+def _invalid_request(message: str) -> JSONResponse:
+    return JSONResponse(status_code=400, content={"code": "INVALID_REQUEST", "message": message})
+
+
+def _parse_product_ids(raw_ids: list[str]) -> list[uuid.UUID] | JSONResponse:
+    product_ids: list[uuid.UUID] = []
+    for raw_id in raw_ids:
+        try:
+            product_ids.append(uuid.UUID(raw_id))
+        except ValueError:
+            return _invalid_request("product_ids must contain valid product ids")
+    return product_ids
+
+
+@router.get("", response_model=ProductPublicPaginatedResponse, status_code=status.HTTP_200_OK)
+def list_public_products_endpoint(
+    limit: int = 20,
+    offset: int = 0,
+    auth_error: JSONResponse | None = Depends(require_public_service_key),
+    db: Session = Depends(get_db),
+) -> ProductPublicPaginatedResponse | JSONResponse:
+    if auth_error is not None:
+        return auth_error
+
+    bounded_limit = min(max(limit, 1), 100)
+    bounded_offset = max(offset, 0)
+    products, total_count = list_public_catalog_products(
+        db,
+        limit=bounded_limit,
+        offset=bounded_offset,
+    )
+    return ProductPublicPaginatedResponse(
+        items=[ProductPublicShortRead.model_validate(product) for product in products],
+        total_count=total_count,
+        limit=bounded_limit,
+        offset=bounded_offset,
+    )
+
+
+@router.post("/batch", response_model=list[ProductPublicRead], status_code=status.HTTP_200_OK)
+def batch_public_products_endpoint(
+    payload: PublicProductBatchRequest,
+    auth_error: JSONResponse | None = Depends(require_public_service_key),
+    db: Session = Depends(get_db),
+) -> list[ProductPublicRead] | JSONResponse:
+    if auth_error is not None:
+        return auth_error
+
+    product_ids = _parse_product_ids(payload.product_ids)
+    if isinstance(product_ids, JSONResponse):
+        return product_ids
+
+    return [
+        ProductPublicRead.model_validate(product)
+        for product in list_public_products_by_ids(db, product_ids)
+    ]

--- a/src/schemas/product.py
+++ b/src/schemas/product.py
@@ -176,7 +176,6 @@ class SKUPublicRead(APIModel):
     def stock_quantity(self) -> int:
         return self.active_quantity
 
-
 class CatalogProductSKURead(SKUPublicRead):
     pass
 
@@ -286,6 +285,44 @@ class ProductPublicRead(APIModel):
         if value is None:
             return []
         return [sku for sku in value if getattr(sku, "active_quantity", 0) > 0]
+
+
+class ProductPublicShortRead(APIModel):
+    id: uuid.UUID
+    title: str
+    status: str
+    category_id: uuid.UUID
+    images: list[ImageOut] = Field(default_factory=list, exclude=True)
+    skus: list[SKUPublicRead] = Field(default_factory=list, exclude=True)
+    created_at: datetime
+
+    @computed_field
+    @property
+    def slug(self) -> str:
+        value = re.sub(r"[^a-z0-9]+", "-", self.title.lower()).strip("-")
+        return f"{value or 'product'}-{self.id}"
+
+    @computed_field
+    @property
+    def min_price(self) -> int:
+        active_prices = [sku.price for sku in self.skus if sku.active_quantity > 0]
+        return min(active_prices)
+
+    @computed_field
+    @property
+    def cover_image(self) -> str | None:
+        return self.images[0].url if self.images else None
+
+
+class ProductPublicPaginatedResponse(APIModel):
+    items: list[ProductPublicShortRead]
+    total_count: int
+    limit: int
+    offset: int
+
+
+class PublicProductBatchRequest(APIModel):
+    product_ids: list[str] = Field(max_length=100)
 
 
 class ProductListRead(APIModel):

--- a/src/schemas/product.py
+++ b/src/schemas/product.py
@@ -177,6 +177,10 @@ class SKUPublicRead(APIModel):
         return self.active_quantity
 
 
+class CatalogProductSKURead(SKUPublicRead):
+    pass
+
+
 class ProductRead(APIModel):
     id: uuid.UUID
     seller_id: uuid.UUID
@@ -286,6 +290,24 @@ class ProductPublicRead(APIModel):
 
 class ProductListRead(APIModel):
     items: list[ProductRead]
+    total_count: int
+    limit: int
+    offset: int
+
+
+class CatalogProductRead(APIModel):
+    id: uuid.UUID
+    title: str
+    description: str
+    status: str
+    category: CategoryOut
+    images: list[ImageOut] = Field(default_factory=list)
+    characteristics: list[CharacteristicOut] = Field(default_factory=list)
+    skus: list[CatalogProductSKURead] = Field(default_factory=list)
+
+
+class CatalogProductListRead(APIModel):
+    items: list[CatalogProductRead]
     total_count: int
     limit: int
     offset: int

--- a/src/services/product_service.py
+++ b/src/services/product_service.py
@@ -1,5 +1,6 @@
 import logging
 import uuid
+from collections.abc import Sequence
 
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session, selectinload
@@ -102,6 +103,30 @@ def list_seller_products(db: Session, seller_id: uuid.UUID, limit: int = 20, off
         .offset(offset)
         .limit(limit)
     ).all()
+    return list(products), total_count
+
+
+def list_catalog_products(
+    db: Session,
+    *,
+    product_ids: Sequence[uuid.UUID] | None = None,
+    limit: int = 20,
+    offset: int = 0,
+) -> tuple[list[Product], int]:
+    filters = [
+        Product.status == ProductStatus.MODERATED,
+        Product.deleted.is_(False),
+        Product.skus.any(SKU.active_quantity > 0),
+    ]
+    if product_ids is not None:
+        filters.append(Product.id.in_(product_ids))
+
+    total_count = db.scalar(select(func.count(Product.id)).where(*filters)) or 0
+    query = _product_query().where(*filters).order_by(Product.id)
+    if product_ids is None:
+        query = query.offset(offset).limit(limit)
+
+    products = db.scalars(query).all()
     return list(products), total_count
 
 

--- a/src/services/product_service.py
+++ b/src/services/product_service.py
@@ -130,6 +130,26 @@ def list_catalog_products(
     return list(products), total_count
 
 
+def list_public_catalog_products(db: Session, *, limit: int = 20, offset: int = 0) -> tuple[list[Product], int]:
+    return list_catalog_products(db, limit=limit, offset=offset)
+
+
+def list_public_products_by_ids(db: Session, product_ids: Sequence[uuid.UUID]) -> list[Product]:
+    if not product_ids:
+        return []
+
+    products, _ = list_catalog_products(db, product_ids=product_ids)
+    product_by_id = {product.id: product for product in products}
+    ordered_products: list[Product] = []
+    seen_ids: set[uuid.UUID] = set()
+    for product_id in product_ids:
+        product = product_by_id.get(product_id)
+        if product is not None and product_id not in seen_ids:
+            ordered_products.append(product)
+            seen_ids.add(product_id)
+    return ordered_products
+
+
 def create_product(db: Session, payload: ProductCreate, seller_id: uuid.UUID) -> Product:
     if not payload.images:
         raise ProductCreateValidationError("images", "At least one image is required")

--- a/tests/api/test_products.py
+++ b/tests/api/test_products.py
@@ -1,3 +1,4 @@
+import json
 from uuid import UUID, uuid4
 
 import pytest
@@ -51,6 +52,20 @@ def assert_uuid(value: str) -> None:
 
 def public_headers(key: str | None = None) -> dict[str, str]:
     return {"X-Service-Key": key or settings.b2c_to_b2b_key}
+
+
+def catalog_headers() -> dict[str, str]:
+    return public_headers()
+
+
+def assert_key_absent(value, key: str) -> None:
+    if isinstance(value, dict):
+        assert key not in value
+        for nested in value.values():
+            assert_key_absent(nested, key)
+    elif isinstance(value, list):
+        for item in value:
+            assert_key_absent(item, key)
 
 
 @pytest.fixture()
@@ -870,3 +885,171 @@ def test_deleted_product_not_in_seller_list(
 
     db_session.refresh(deleted_product)
     assert deleted_product.deleted is True
+
+
+def test_catalog_returns_moderated_in_stock_products(client, db_session: Session, test_product_factory):
+    visible_product = test_product_factory(status=ProductStatus.MODERATED)
+    visible_sku = create_existing_sku(db_session, visible_product, active_quantity=5)
+    create_existing_sku(db_session, visible_product, active_quantity=0)
+
+    response = client.get("/api/v1/public/products", headers=catalog_headers())
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total_count"] == 1
+    assert [item["id"] for item in body["items"]] == [str(visible_product.id)]
+    product = body["items"][0]
+    assert product["status"] == "MODERATED"
+    assert product["category"] == {"id": str(visible_product.category.id), "name": visible_product.category.name}
+    assert product["images"] == [
+        {"id": str(visible_product.images[0].id), "url": "/s3/iphone15-front.jpg", "ordering": 0}
+    ]
+    assert product["characteristics"] == [
+        {"id": str(visible_product.characteristics[0].id), "name": "Brand", "value": "Apple"}
+    ]
+    response_sku = product["skus"][0]
+    assert product["skus"] == [
+        {
+            "id": str(visible_sku.id),
+            "product_id": str(visible_product.id),
+            "name": "128GB Black",
+            "price": 9999000,
+            "discount": 0,
+            "active_quantity": 5,
+            "article": "IPHONE15-BLACK-128",
+            "images": [
+                {
+                    "id": response_sku["images"][0]["id"],
+                    "url": "/s3/iphone15-black-128.jpg",
+                    "ordering": 0,
+                }
+            ],
+            "characteristics": [
+                {"id": str(visible_sku.characteristics[0].id), "name": "Storage", "value": "128GB"}
+            ],
+            "stock_quantity": 5,
+        }
+    ]
+    assert_uuid(response_sku["images"][0]["id"])
+
+
+def test_catalog_excludes_hard_blocked(client, db_session: Session, test_product_factory):
+    visible_product = test_product_factory(status=ProductStatus.MODERATED)
+    create_existing_sku(db_session, visible_product, active_quantity=3)
+
+    hidden_statuses = [
+        ProductStatus.CREATED,
+        ProductStatus.DRAFT,
+        ProductStatus.ON_MODERATION,
+        ProductStatus.BLOCKED,
+        ProductStatus.REJECTED,
+        ProductStatus.HARD_BLOCKED,
+    ]
+    for status in hidden_statuses:
+        product = test_product_factory(status=status)
+        create_existing_sku(db_session, product, active_quantity=3)
+
+    deleted_product = test_product_factory(status=ProductStatus.MODERATED, deleted=True)
+    create_existing_sku(db_session, deleted_product, active_quantity=3)
+    no_sku_product = test_product_factory(status=ProductStatus.MODERATED)
+    out_of_stock_product = test_product_factory(status=ProductStatus.MODERATED)
+    create_existing_sku(db_session, out_of_stock_product, active_quantity=0)
+
+    response = client.get("/api/v1/public/products", headers=catalog_headers())
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total_count"] == 1
+    assert [item["id"] for item in body["items"]] == [str(visible_product.id)]
+    hidden_ids = {str(deleted_product.id), str(no_sku_product.id), str(out_of_stock_product.id)}
+    hidden_ids.update(str(product.id) for product in db_session.query(Product).all() if product.id != visible_product.id)
+    assert hidden_ids.isdisjoint({item["id"] for item in body["items"]})
+
+
+def test_catalog_missing_service_key_returns_401(client, db_session: Session, test_product_factory, auth_headers):
+    product = test_product_factory(status=ProductStatus.MODERATED)
+    create_existing_sku(db_session, product, active_quantity=1)
+
+    missing_response = client.get("/api/v1/public/products")
+    assert missing_response.status_code == 401
+    assert missing_response.json() == {"code": "UNAUTHORIZED", "message": "Authorization required"}
+
+    invalid_response = client.get("/api/v1/public/products", headers={"X-Service-Key": "wrong"})
+    assert invalid_response.status_code == 401
+    assert invalid_response.json() == {"code": "UNAUTHORIZED", "message": "Authorization required"}
+
+    seller_response = client.get("/api/v1/products", headers=auth_headers(SELLER_ID))
+    assert seller_response.status_code == 200
+    seller_body = seller_response.json()
+    assert seller_body["total_count"] == 1
+    assert seller_body["items"][0]["seller_id"] == SELLER_ID
+
+
+def test_catalog_response_has_no_cost_price(client, db_session: Session, test_product_factory):
+    product = test_product_factory(
+        status=ProductStatus.MODERATED,
+        blocking_reason={"title": "hidden"},
+        field_reports=[{"field_name": "title", "comment": "hidden"}],
+    )
+    create_existing_sku(db_session, product, active_quantity=4, reserved_quantity=2)
+
+    response = client.get("/api/v1/public/products", headers=catalog_headers())
+
+    assert response.status_code == 200
+    body = response.json()
+    serialized = json.dumps(body)
+    for sensitive_key in [
+        "cost_price",
+        "reserved_quantity",
+        "seller_id",
+        "deleted",
+        "blocking_reason",
+        "field_reports",
+    ]:
+        assert sensitive_key not in serialized
+        assert_key_absent(body, sensitive_key)
+
+
+def test_batch_ids_returns_visible_subset(client, db_session: Session, test_product_factory):
+    visible_product = test_product_factory(status=ProductStatus.MODERATED)
+    create_existing_sku(db_session, visible_product, active_quantity=7)
+    hidden_product = test_product_factory(status=ProductStatus.HARD_BLOCKED)
+    create_existing_sku(db_session, hidden_product, active_quantity=7)
+    deleted_product = test_product_factory(status=ProductStatus.MODERATED, deleted=True)
+    create_existing_sku(db_session, deleted_product, active_quantity=7)
+
+    response = client.post(
+        "/api/v1/public/products/batch",
+        json={
+            "product_ids": [
+                str(visible_product.id),
+                str(hidden_product.id),
+                str(deleted_product.id),
+                str(uuid4()),
+            ]
+        },
+        headers=catalog_headers(),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert [item["id"] for item in body] == [str(visible_product.id)]
+
+    repeated_response = client.get(
+        "/api/v1/public/products",
+        params=[("ids", str(visible_product.id)), ("ids", str(hidden_product.id)), ("ids", str(uuid4()))],
+        headers=catalog_headers(),
+    )
+    assert repeated_response.status_code == 200
+    assert [item["id"] for item in repeated_response.json()["items"]] == [str(visible_product.id)]
+
+    invalid_response = client.post(
+        "/api/v1/public/products/batch",
+        json={"product_ids": [str(visible_product.id), "not-an-id"]},
+        headers=catalog_headers(),
+    )
+    assert invalid_response.status_code == 400
+    assert invalid_response.json() == {
+        "code": "INVALID_REQUEST",
+        "message": "ids must be a comma-separated list of product ids",
+    }

--- a/tests/api/test_products.py
+++ b/tests/api/test_products.py
@@ -887,75 +887,60 @@ def test_deleted_product_not_in_seller_list(
     assert deleted_product.deleted is True
 
 
-def test_catalog_returns_moderated_in_stock_products(client, db_session: Session, test_product_factory):
+def test_public_catalog_returns_short_paginated_products(client, db_session: Session, test_product_factory):
     visible_product = test_product_factory(status=ProductStatus.MODERATED)
     visible_sku = create_existing_sku(db_session, visible_product, active_quantity=5)
+    visible_sku.price = 1234500
     create_existing_sku(db_session, visible_product, active_quantity=0)
+    db_session.commit()
 
-    response = client.get("/api/v1/public/products", headers=catalog_headers())
+    response = client.get("/api/v1/public/products", headers=public_headers(), params={"limit": 10, "offset": 0})
 
     assert response.status_code == 200
     body = response.json()
     assert body["total_count"] == 1
-    assert [item["id"] for item in body["items"]] == [str(visible_product.id)]
-    product = body["items"][0]
-    assert product["status"] == "MODERATED"
-    assert product["category"] == {"id": str(visible_product.category.id), "name": visible_product.category.name}
-    assert product["images"] == [
-        {"id": str(visible_product.images[0].id), "url": "/s3/iphone15-front.jpg", "ordering": 0}
-    ]
-    assert product["characteristics"] == [
-        {"id": str(visible_product.characteristics[0].id), "name": "Brand", "value": "Apple"}
-    ]
-    response_sku = product["skus"][0]
-    assert product["skus"] == [
+    assert body["limit"] == 10
+    assert body["offset"] == 0
+    assert body["items"] == [
         {
-            "id": str(visible_sku.id),
-            "product_id": str(visible_product.id),
-            "name": "128GB Black",
-            "price": 9999000,
-            "discount": 0,
-            "active_quantity": 5,
-            "article": "IPHONE15-BLACK-128",
-            "images": [
-                {
-                    "id": response_sku["images"][0]["id"],
-                    "url": "/s3/iphone15-black-128.jpg",
-                    "ordering": 0,
-                }
-            ],
-            "characteristics": [
-                {"id": str(visible_sku.characteristics[0].id), "name": "Storage", "value": "128GB"}
-            ],
-            "stock_quantity": 5,
+            "id": str(visible_product.id),
+            "title": visible_product.title,
+            "status": "MODERATED",
+            "category_id": str(visible_product.category_id),
+            "created_at": body["items"][0]["created_at"],
+            "slug": f"iphone-15-pro-max-{visible_product.id}",
+            "min_price": 1234500,
+            "cover_image": "/s3/iphone15-front.jpg",
         }
     ]
-    assert_uuid(response_sku["images"][0]["id"])
 
 
-def test_catalog_excludes_hard_blocked(client, db_session: Session, test_product_factory):
+def test_public_catalog_excludes_non_moderated_deleted_and_out_of_stock(
+    client,
+    db_session: Session,
+    test_product_factory,
+):
     visible_product = test_product_factory(status=ProductStatus.MODERATED)
     create_existing_sku(db_session, visible_product, active_quantity=3)
 
-    hidden_statuses = [
+    for product_status in [
         ProductStatus.CREATED,
         ProductStatus.DRAFT,
         ProductStatus.ON_MODERATION,
         ProductStatus.BLOCKED,
         ProductStatus.REJECTED,
         ProductStatus.HARD_BLOCKED,
-    ]
-    for status in hidden_statuses:
-        product = test_product_factory(status=status)
+    ]:
+        product = test_product_factory(status=product_status)
         create_existing_sku(db_session, product, active_quantity=3)
 
     deleted_product = test_product_factory(status=ProductStatus.MODERATED, deleted=True)
     create_existing_sku(db_session, deleted_product, active_quantity=3)
     no_sku_product = test_product_factory(status=ProductStatus.MODERATED)
     out_of_stock_product = test_product_factory(status=ProductStatus.MODERATED)
-    create_existing_sku(db_session, out_of_stock_product, active_quantity=0)
+    create_existing_sku(db_session, out_of_stock_product, active_quantity=0, reserved_quantity=4)
 
-    response = client.get("/api/v1/public/products", headers=catalog_headers())
+    response = client.get("/api/v1/public/products", headers=public_headers())
 
     assert response.status_code == 200
     body = response.json()
@@ -966,7 +951,7 @@ def test_catalog_excludes_hard_blocked(client, db_session: Session, test_product
     assert hidden_ids.isdisjoint({item["id"] for item in body["items"]})
 
 
-def test_catalog_missing_service_key_returns_401(client, db_session: Session, test_product_factory, auth_headers):
+def test_public_catalog_requires_valid_service_key(client, db_session: Session, test_product_factory):
     product = test_product_factory(status=ProductStatus.MODERATED)
     create_existing_sku(db_session, product, active_quantity=1)
 
@@ -978,14 +963,8 @@ def test_catalog_missing_service_key_returns_401(client, db_session: Session, te
     assert invalid_response.status_code == 401
     assert invalid_response.json() == {"code": "UNAUTHORIZED", "message": "Authorization required"}
 
-    seller_response = client.get("/api/v1/products", headers=auth_headers(SELLER_ID))
-    assert seller_response.status_code == 200
-    seller_body = seller_response.json()
-    assert seller_body["total_count"] == 1
-    assert seller_body["items"][0]["seller_id"] == SELLER_ID
 
-
-def test_catalog_response_has_no_cost_price(client, db_session: Session, test_product_factory):
+def test_public_catalog_response_has_no_seller_only_fields(client, db_session: Session, test_product_factory):
     product = test_product_factory(
         status=ProductStatus.MODERATED,
         blocking_reason={"title": "hidden"},
@@ -993,7 +972,7 @@ def test_catalog_response_has_no_cost_price(client, db_session: Session, test_pr
     )
     create_existing_sku(db_session, product, active_quantity=4, reserved_quantity=2)
 
-    response = client.get("/api/v1/public/products", headers=catalog_headers())
+    response = client.get("/api/v1/public/products", headers=public_headers())
 
     assert response.status_code == 200
     body = response.json()
@@ -1005,18 +984,76 @@ def test_catalog_response_has_no_cost_price(client, db_session: Session, test_pr
         "deleted",
         "blocking_reason",
         "field_reports",
+        "moderator_comment",
+        "blocking_reason_id",
     ]:
         assert sensitive_key not in serialized
         assert_key_absent(body, sensitive_key)
 
 
-def test_batch_ids_returns_visible_subset(client, db_session: Session, test_product_factory):
+def test_public_batch_returns_visible_full_public_products(client, db_session: Session, test_product_factory):
+    product = test_product_factory(status=ProductStatus.MODERATED)
+    active_sku = create_existing_sku(
+        db_session,
+        product,
+        active_quantity=6,
+        reserved_quantity=2,
+        article="IPHONE15-BLACK-128",
+    )
+    create_existing_sku(db_session, product, active_quantity=0, reserved_quantity=5, image="")
+
+    response = client.post(
+        "/api/v1/public/products/batch",
+        json={"product_ids": [str(product.id)]},
+        headers=public_headers(),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body) == 1
+    public_product = body[0]
+    assert public_product["id"] == str(product.id)
+    assert public_product["seller_id"] == SELLER_ID
+    assert public_product["category_id"] == str(product.category_id)
+    assert public_product["title"] == product.title
+    assert public_product["slug"] == f"iphone-15-pro-max-{product.id}"
+    assert public_product["status"] == "MODERATED"
+    assert len(public_product["skus"]) == 1
+    sku = public_product["skus"][0]
+    assert sku["id"] == str(active_sku.id)
+    assert sku["product_id"] == str(product.id)
+    assert sku["active_quantity"] == 6
+    assert sku["stock_quantity"] == 6
+    assert sku["images"] == [
+        {"id": sku["images"][0]["id"], "url": "/s3/iphone15-black-128.jpg", "ordering": 0}
+    ]
+    assert_uuid(sku["images"][0]["id"])
+    assert sku["images"][0]["id"] != str(active_sku.id)
+    for sensitive_key in [
+        "cost_price",
+        "reserved_quantity",
+        "deleted",
+        "blocking_reason",
+        "field_reports",
+        "moderator_comment",
+        "blocking_reason_id",
+    ]:
+        assert_key_absent(public_product, sensitive_key)
+
+
+def test_public_batch_omits_missing_hidden_deleted_and_out_of_stock_products(
+    client,
+    db_session: Session,
+    test_product_factory,
+):
     visible_product = test_product_factory(status=ProductStatus.MODERATED)
     create_existing_sku(db_session, visible_product, active_quantity=7)
     hidden_product = test_product_factory(status=ProductStatus.HARD_BLOCKED)
     create_existing_sku(db_session, hidden_product, active_quantity=7)
     deleted_product = test_product_factory(status=ProductStatus.MODERATED, deleted=True)
     create_existing_sku(db_session, deleted_product, active_quantity=7)
+    out_of_stock_product = test_product_factory(status=ProductStatus.MODERATED)
+    create_existing_sku(db_session, out_of_stock_product, active_quantity=0, reserved_quantity=3)
 
     response = client.post(
         "/api/v1/public/products/batch",
@@ -1026,30 +1063,46 @@ def test_batch_ids_returns_visible_subset(client, db_session: Session, test_prod
                 str(hidden_product.id),
                 str(deleted_product.id),
                 str(uuid4()),
+                str(out_of_stock_product.id),
+                str(uuid4()),
             ]
         },
-        headers=catalog_headers(),
+        headers=public_headers(),
     )
 
     assert response.status_code == 200
-    body = response.json()
-    assert [item["id"] for item in body] == [str(visible_product.id)]
+    assert [item["id"] for item in response.json()] == [str(visible_product.id)]
 
-    repeated_response = client.get(
-        "/api/v1/public/products",
-        params=[("ids", str(visible_product.id)), ("ids", str(hidden_product.id)), ("ids", str(uuid4()))],
-        headers=catalog_headers(),
-    )
-    assert repeated_response.status_code == 200
-    assert [item["id"] for item in repeated_response.json()["items"]] == [str(visible_product.id)]
+
+def test_public_batch_requires_valid_service_key(client, db_session: Session, test_product_factory):
+    product = test_product_factory(status=ProductStatus.MODERATED)
+    create_existing_sku(db_session, product, active_quantity=1)
+
+    missing_response = client.post("/api/v1/public/products/batch", json={"product_ids": [str(product.id)]})
+    assert missing_response.status_code == 401
+    assert missing_response.json() == {"code": "UNAUTHORIZED", "message": "Authorization required"}
 
     invalid_response = client.post(
         "/api/v1/public/products/batch",
-        json={"product_ids": [str(visible_product.id), "not-an-id"]},
-        headers=catalog_headers(),
+        json={"product_ids": [str(product.id)]},
+        headers={"X-Service-Key": "wrong"},
     )
-    assert invalid_response.status_code == 400
-    assert invalid_response.json() == {
-        "code": "INVALID_REQUEST",
-        "message": "ids must be a comma-separated list of product ids",
-    }
+    assert invalid_response.status_code == 401
+    assert invalid_response.json() == {"code": "UNAUTHORIZED", "message": "Authorization required"}
+
+
+def test_legacy_products_service_key_catalog_route_remains_supported(
+    client,
+    db_session: Session,
+    test_product_factory,
+):
+    product = test_product_factory(status=ProductStatus.MODERATED)
+    create_existing_sku(db_session, product, active_quantity=2)
+
+    response = client.get("/api/v1/products", headers=catalog_headers())
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total_count"] == 1
+    assert [item["id"] for item in body["items"]] == [str(product.id)]
+    assert "min_price" in body["items"][0]


### PR DESCRIPTION
# US-B2B-07 Summary

US-B2B-07 is migrated to the final authoritative `flow/openapi.yaml` public catalog contract. For the affected public catalog list and batch endpoints, this contract matches the previously reviewed `neomarket-b2b.yaml` public catalog contract.

Migrated the B2C public catalog surface to the authoritative `flow/openapi.yaml` paths for this slice:

- `GET /api/v1/public/products`
- `POST /api/v1/public/products/batch`

The legacy service-key catalog entrypoint `GET /api/v1/products` remains available for compatibility, while seller `GET /api/v1/products`, seller/public `GET /api/v1/products/{product_id}`, product create/edit/delete, SKU, and invoice behavior are preserved.

Public catalog routes require `X-Service-Key == settings.b2c_to_b2b_key`; missing or invalid service keys return `401 {"code":"UNAUTHORIZED","message":"Authorization required"}`.

Public list and batch visibility is restricted to products with `status=MODERATED`, `deleted=false`, and at least one SKU where `active_quantity > 0`. Public SKU arrays include only in-stock SKUs. Missing, hidden, deleted, non-moderated, nonexistent, and out-of-stock products are omitted from batch responses instead of failing the whole batch.

Public list responses use canonical short products with `id`, `title`, `slug`, `status`, `category_id`, `min_price`, `cover_image`, and `created_at`. Public batch responses use the full public product schema. Public responses do not expose seller-only or moderation/deletion fields such as `cost_price`, `reserved_quantity`, `deleted`, `blocking_reason`, `field_reports`, `moderator_comment`, or `blocking_reason_id`. Public SKU `stock_quantity` equals `active_quantity`.

Temporary compatibility note: the current database stores one SKU image URL directly on `skus.image` and has no SKU image table. Public SKU image responses therefore synthesize stable UUID response-boundary IDs using the seed `sku-image:{sku_id}:0` when a SKU image URL exists. The raw SKU ID is not reused as `images[].id`.

Unsupported OpenAPI surface in this branch: `GET /api/v1/public/products` implements only `limit` and `offset`. `category_id`, `search`, price filters, seller filters, dynamic `filters`, and advanced `sort` are documented by `flow/openapi.yaml` but intentionally deferred outside US-B2B-07.

# US-B2B-07 Validation

Pytest proof commands:

```powershell
python -m pytest tests/api/test_products.py -vv
python -m pytest tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py -vv
```

Required scenario results:

- `test_public_catalog_returns_short_paginated_products`: passed
- `test_public_catalog_excludes_non_moderated_deleted_and_out_of_stock`: passed
- `test_public_catalog_requires_valid_service_key`: passed
- `test_public_catalog_response_has_no_seller_only_fields`: passed
- `test_public_batch_returns_visible_full_public_products`: passed
- `test_public_batch_omits_missing_hidden_deleted_and_out_of_stock_products`: passed
- `test_public_batch_requires_valid_service_key`: passed
- `test_legacy_products_service_key_catalog_route_remains_supported`: passed

Suite results:

- `tests/api/test_products.py`: 31 passed
- `tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py`: 53 passed

# ADR: Public Catalog Routing And Compatibility

Options considered:

- Keep only the legacy `GET /api/v1/products` service-key mode: lowest route churn, but it leaves US-B2B-07 off the authoritative `flow/openapi.yaml` public catalog paths.
- Move all B2C catalog traffic to `/api/v1/public/products` and remove legacy behavior: cleanest contract, but breaks existing stacked behavior and callers using the service-key route.
- Add canonical public routes and keep the legacy service-key route as a compatibility alias: selected. This aligns new B2C catalog calls with `flow/openapi.yaml`, preserves existing seller/product behavior, and keeps field-leak risk controlled through dedicated public schemas and shared service visibility helpers.

Decision: canonical list and batch live under `/api/v1/public/products`. The legacy `GET /api/v1/products` service-key branch remains as a small compatibility route returning the same short public list shape. Batch lookup is canonicalized to `POST /api/v1/public/products/batch`; old `?ids=` test coverage was removed.

# ADR: Deferred Public Catalog Filters

Options considered:

- Implement every filter declared in `flow/openapi.yaml`: aligns the broad schema immediately, but expands this migration into search, price filtering, seller filtering, dynamic characteristic filtering, and sort behavior that are not part of the US-B2B-07 slice.
- Reject unsupported query parameters explicitly: clearer to clients, but risks breaking forward-compatible callers that may already send no-op parameters through a gateway.
- Implement only pagination and document the unsupported surface: selected for this branch. It keeps behavior narrow and testable while making the contract gap explicit.

Decision: only `limit` and `offset` are active for `GET /api/v1/public/products` in this slice. `category_id`, `search`, `min_price`, `max_price`, `seller_id`, dynamic `filters`, and advanced `sort` remain deferred.