### PR TITLE
US-B2B-08: Implement SKU reservation

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -406,17 +406,21 @@ Decision: only `limit` and `offset` are active for `GET /api/v1/public/products`
 
 # US-B2B-08 Summary
 
-Implemented service-to-service reserve/unreserve endpoints on top of the stacked US-B2B-01 through US-B2B-07 branch.
+Migrated US-B2B-08 reserve/unreserve to the canonical inventory routes from `flow/openapi.yaml`. This matches the previously reviewed `neomarket-b2b.yaml` inventory reserve/unreserve contract.
 
-Added `POST /api/v1/reserve` and `POST /api/v1/unreserve`, both authenticated only by `X-Service-Key == settings.b2c_to_b2b_key`. Seller JWTs are not accepted as a substitute. Reserve validates `idempotency_key`, non-empty `items`, positive integer `sku_id`, and `quantity > 0`; unreserve validates `order_id`, non-empty `items`, positive integer `sku_id`, and `quantity > 0`.
+Added `POST /api/v1/inventory/reserve` and `POST /api/v1/inventory/unreserve`, both authenticated only by `X-Service-Key == settings.b2c_to_b2b_key`. Seller JWTs are not accepted as a substitute. Reserve validates `idempotency_key`, `order_id`, non-empty `items`, positive integer `sku_id`, and `quantity > 0`; unreserve validates `order_id`, non-empty `items`, positive integer `sku_id`, and `quantity > 0`.
+
+Kept `POST /api/v1/reserve` and `POST /api/v1/unreserve` as legacy compatibility routes with their original response shapes.
 
 Reserve is all-or-nothing against catalog-visible stock only: parent product must be `MODERATED`, not deleted, and have enough `active_quantity`. Hidden, deleted, nonexistent, and non-moderated SKUs return the non-leaking reserve conflict shape with `available: 0` and `OUT_OF_STOCK`; visible SKUs with positive but insufficient stock return `INSUFFICIENT_STOCK`. Successful reserve decrements `active_quantity`, increments `reserved_quantity`, stores a cached success response in `reserve_operations`, and emits `SKU_OUT_OF_STOCK` after commit when a SKU reaches zero active stock.
 
-Unreserve restores stock in one transaction by moving quantities from `reserved_quantity` back to `active_quantity`. If any item would make `reserved_quantity` negative, it returns `409 {"code":"CONFLICT","message":"Insufficient reserved quantity"}` and rolls back all changes. No persistent unreserve replay was added because the existing schema has no order-operation storage table.
+Canonical reserve returns `{"order_id","status":"RESERVED","reserved_at"}`. Canonical reserve idempotency includes `order_id` in the normalized request hash, so same `idempotency_key` + same `order_id` + same normalized items replays with the original `reserved_at`, while changing either `order_id` or items returns `409 CONFLICT`. Legacy reserve continues to hash without `order_id`.
 
-Added migration `0008_add_reserve_operations.py` with `idempotency_key`, `request_hash`, normalized `request_payload`, cached success `response`, and `created_at`. Reserve request hashing normalizes by aggregating quantities per `sku_id` and sorting items, so reordered or duplicate-line equivalent requests replay from cache without double deduction. Same key with different normalized payload returns `409 CONFLICT`.
+Canonical reserve stock conflicts now return `409 {"code":"CONFLICT","message":"Unable to reserve inventory","details":{"failed_items":[...]}}`. The legacy reserve conflict shape remains `{"reserved":false,"failed_items":[...]}`.
 
-`flow/b2b.yaml` does not define `/api/v1/reserve` or `/api/v1/unreserve`; this implementation follows `flow/b2b-flows.md#reserve-sku` and leaves `flow/*` unchanged.
+Unreserve restores stock in one transaction by moving quantities from `reserved_quantity` back to `active_quantity`. Canonical unreserve returns `{"order_id","status":"UNRESERVED","processed_at"}`. If any item would make `reserved_quantity` negative, it returns `409 {"code":"CONFLICT","message":"Insufficient reserved quantity"}` and rolls back all changes. No persistent unreserve replay was added; unreserve idempotency remains unchanged from the existing US-B2B-08 behavior because the schema has no order-operation storage table.
+
+No US-B2B-09+ behavior was implemented: no moderation event alias, no fulfill, no seller list migration, and no SKU delete behavior.
 
 PostgreSQL production uses `SELECT FOR UPDATE` for SKU rows inside the reserve/unreserve transaction. SQLite tests verify deterministic all-or-nothing behavior but do not prove real row-lock semantics. B2C event delivery is best-effort after a successful reserve commit; delivery failure is logged and does not roll back stock changes.
 
@@ -426,30 +430,30 @@ Pytest proof commands:
 
 ```powershell
 python -m pytest tests/api/test_reservations.py -vv
-python -m pytest tests/api/test_reservations.py -vv -k "test_reserve_all_skus_succeeds or test_partial_insufficient_stock_returns_409_all_rollback or test_idempotent_reserve_returns_200_without_double_deduction or test_sku_out_of_stock_event_emitted or test_unreserve_restores_quantities"
 python -m pytest tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py tests/api/test_reservations.py -vv
 ```
 
 Required scenario results:
 
-- `test_reserve_all_skus_succeeds`: passed
-- `test_partial_insufficient_stock_returns_409_all_rollback`: passed
-- `test_idempotent_reserve_returns_200_without_double_deduction`: passed
-- `test_sku_out_of_stock_event_emitted`: passed
-- `test_unreserve_restores_quantities`: passed
+- `test_inventory_reserve_returns_openapi_response`: passed
+- `test_inventory_reserve_requires_order_id`: passed
+- `test_inventory_reserve_idempotent_replay_returns_same_reserved_at_without_double_deduction`: passed
+- `test_inventory_reserve_same_key_different_order_id_returns_409`: passed
+- `test_inventory_reserve_conflict_returns_error_with_failed_items_details_and_rolls_back`: passed
+- `test_inventory_unreserve_returns_openapi_response`: passed
+- `test_legacy_reserve_and_unreserve_routes_keep_response_shapes`: passed
 
 Suite results:
 
-- `tests/api/test_reservations.py`: 11 passed
-- Required US-B2B-08 scenarios: 5 passed, 6 deselected
-- `tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py tests/api/test_reservations.py`: 48 passed
+- `tests/api/test_reservations.py`: 18 passed
+- `tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py tests/api/test_reservations.py`: 71 passed
 
-# ADR: Reserve Transaction Strategy
+# ADR: Inventory OpenAPI Migration Strategy
 
 Options considered:
 
-- One transaction with `SELECT FOR UPDATE`: selected. It gives the best correctness/performance balance for concurrent reserve requests in this FastAPI/SQLAlchemy service and keeps implementation complexity low.
-- Optimistic locking: would require version columns, conflict retries, and broader model changes for little benefit in the current single-database stock mutation.
-- Two-phase commit: unnecessary and too complex because reserve/unreserve mutate one database; B2C event delivery is intentionally best-effort after commit.
+- Add canonical inventory routes on the existing reservation service: selected. It aligns B2C calls with `flow/openapi.yaml` while preserving the tested reserve transaction and event semantics.
+- Replace legacy reserve/unreserve routes: rejected because existing callers still depend on `/api/v1/reserve` and `/api/v1/unreserve` response shapes.
+- Add persistent unreserve replay storage: rejected for this migration because it would require a new order-operation model beyond US-B2B-08 and is explicitly deferred.
 
-Decision: use one database transaction, claim the idempotency key by inserting/flushing `reserve_operations`, lock all requested SKU rows with `SELECT FOR UPDATE` where supported, validate all items, mutate stock, cache the success response, and commit. Validation/stock conflicts roll back the operation row and stock changes, so failed reserve attempts are not replay-cached and emit no events.
+Decision: add `POST /api/v1/inventory/reserve` and `POST /api/v1/inventory/unreserve` as canonical wrappers over the existing reservation service. Canonical reserve passes `order_id` into the normalized idempotency hash and derives `reserved_at` from `ReserveOperation.created_at`; legacy reserve omits `order_id` and keeps its cached response. Canonical unreserve returns the OpenAPI response shape but does not add persistent replay.

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -408,7 +408,7 @@ Decision: only `limit` and `offset` are active for `GET /api/v1/public/products`
 
 Migrated US-B2B-08 reserve/unreserve to the canonical inventory routes from `flow/openapi.yaml`. This matches the previously reviewed `neomarket-b2b.yaml` inventory reserve/unreserve contract.
 
-Added `POST /api/v1/inventory/reserve` and `POST /api/v1/inventory/unreserve`, both authenticated only by `X-Service-Key == settings.b2c_to_b2b_key`. Seller JWTs are not accepted as a substitute. Reserve validates `idempotency_key`, `order_id`, non-empty `items`, positive integer `sku_id`, and `quantity > 0`; unreserve validates `order_id`, non-empty `items`, positive integer `sku_id`, and `quantity > 0`.
+Added `POST /api/v1/inventory/reserve` and `POST /api/v1/inventory/unreserve`, both authenticated only by `X-Service-Key == settings.b2c_to_b2b_key`. Seller JWTs are not accepted as a substitute. Reserve validates `idempotency_key`, `order_id`, non-empty `items`, UUID-format `sku_id`, and `quantity > 0`; unreserve validates `order_id`, non-empty `items`, UUID-format `sku_id`, and `quantity > 0`.
 
 Kept `POST /api/v1/reserve` and `POST /api/v1/unreserve` as legacy compatibility routes with their original response shapes.
 
@@ -446,7 +446,7 @@ Required scenario results:
 Suite results:
 
 - `tests/api/test_reservations.py`: 18 passed
-- `tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py tests/api/test_reservations.py`: 71 passed
+- `tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py tests/api/test_reservations.py`: 75 passed
 
 # ADR: Inventory OpenAPI Migration Strategy
 
@@ -457,3 +457,9 @@ Options considered:
 - Add persistent unreserve replay storage: rejected for this migration because it would require a new order-operation model beyond US-B2B-08 and is explicitly deferred.
 
 Decision: add `POST /api/v1/inventory/reserve` and `POST /api/v1/inventory/unreserve` as canonical wrappers over the existing reservation service. Canonical reserve passes `order_id` into the normalized idempotency hash and derives `reserved_at` from `ReserveOperation.created_at`; legacy reserve omits `order_id` and keeps its cached response. Canonical unreserve returns the OpenAPI response shape but does not add persistent replay.
+
+# ADR: Reservation UUID Request Boundary
+
+After the UUID migration, reservation HTTP request bodies must carry `sku_id` as JSON strings because real clients cannot send Python `uuid.UUID` objects. The route parses those strings into `uuid.UUID` instances for service and SQLAlchemy lookups, while cached reservation payloads, API responses, failed items, and B2C event payloads serialize UUID identifiers back to strings at the JSON boundary.
+
+Decision: keep reservation lookup and schema types UUID-aware, remove integer SKU parsing from reserve/unreserve normalization, and update reservation tests to send `str(sku.id)` in all JSON payloads. Reservation business logic, idempotency rules, all-or-nothing stock behavior, and legacy/canonical route behavior are unchanged.

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -401,3 +401,55 @@ Options considered:
 - Implement only pagination and document the unsupported surface: selected for this branch. It keeps behavior narrow and testable while making the contract gap explicit.
 
 Decision: only `limit` and `offset` are active for `GET /api/v1/public/products` in this slice. `category_id`, `search`, `min_price`, `max_price`, `seller_id`, dynamic `filters`, and advanced `sort` remain deferred.
+
+---
+
+# US-B2B-08 Summary
+
+Implemented service-to-service reserve/unreserve endpoints on top of the stacked US-B2B-01 through US-B2B-07 branch.
+
+Added `POST /api/v1/reserve` and `POST /api/v1/unreserve`, both authenticated only by `X-Service-Key == settings.b2c_to_b2b_key`. Seller JWTs are not accepted as a substitute. Reserve validates `idempotency_key`, non-empty `items`, positive integer `sku_id`, and `quantity > 0`; unreserve validates `order_id`, non-empty `items`, positive integer `sku_id`, and `quantity > 0`.
+
+Reserve is all-or-nothing against catalog-visible stock only: parent product must be `MODERATED`, not deleted, and have enough `active_quantity`. Hidden, deleted, nonexistent, and non-moderated SKUs return the non-leaking reserve conflict shape with `available: 0` and `OUT_OF_STOCK`; visible SKUs with positive but insufficient stock return `INSUFFICIENT_STOCK`. Successful reserve decrements `active_quantity`, increments `reserved_quantity`, stores a cached success response in `reserve_operations`, and emits `SKU_OUT_OF_STOCK` after commit when a SKU reaches zero active stock.
+
+Unreserve restores stock in one transaction by moving quantities from `reserved_quantity` back to `active_quantity`. If any item would make `reserved_quantity` negative, it returns `409 {"code":"CONFLICT","message":"Insufficient reserved quantity"}` and rolls back all changes. No persistent unreserve replay was added because the existing schema has no order-operation storage table.
+
+Added migration `0008_add_reserve_operations.py` with `idempotency_key`, `request_hash`, normalized `request_payload`, cached success `response`, and `created_at`. Reserve request hashing normalizes by aggregating quantities per `sku_id` and sorting items, so reordered or duplicate-line equivalent requests replay from cache without double deduction. Same key with different normalized payload returns `409 CONFLICT`.
+
+`flow/b2b.yaml` does not define `/api/v1/reserve` or `/api/v1/unreserve`; this implementation follows `flow/b2b-flows.md#reserve-sku` and leaves `flow/*` unchanged.
+
+PostgreSQL production uses `SELECT FOR UPDATE` for SKU rows inside the reserve/unreserve transaction. SQLite tests verify deterministic all-or-nothing behavior but do not prove real row-lock semantics. B2C event delivery is best-effort after a successful reserve commit; delivery failure is logged and does not roll back stock changes.
+
+# US-B2B-08 Validation
+
+Pytest proof commands:
+
+```powershell
+python -m pytest tests/api/test_reservations.py -vv
+python -m pytest tests/api/test_reservations.py -vv -k "test_reserve_all_skus_succeeds or test_partial_insufficient_stock_returns_409_all_rollback or test_idempotent_reserve_returns_200_without_double_deduction or test_sku_out_of_stock_event_emitted or test_unreserve_restores_quantities"
+python -m pytest tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py tests/api/test_reservations.py -vv
+```
+
+Required scenario results:
+
+- `test_reserve_all_skus_succeeds`: passed
+- `test_partial_insufficient_stock_returns_409_all_rollback`: passed
+- `test_idempotent_reserve_returns_200_without_double_deduction`: passed
+- `test_sku_out_of_stock_event_emitted`: passed
+- `test_unreserve_restores_quantities`: passed
+
+Suite results:
+
+- `tests/api/test_reservations.py`: 11 passed
+- Required US-B2B-08 scenarios: 5 passed, 6 deselected
+- `tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py tests/api/test_reservations.py`: 48 passed
+
+# ADR: Reserve Transaction Strategy
+
+Options considered:
+
+- One transaction with `SELECT FOR UPDATE`: selected. It gives the best correctness/performance balance for concurrent reserve requests in this FastAPI/SQLAlchemy service and keeps implementation complexity low.
+- Optimistic locking: would require version columns, conflict retries, and broader model changes for little benefit in the current single-database stock mutation.
+- Two-phase commit: unnecessary and too complex because reserve/unreserve mutate one database; B2C event delivery is intentionally best-effort after commit.
+
+Decision: use one database transaction, claim the idempotency key by inserting/flushing `reserve_operations`, lock all requested SKU rows with `SELECT FOR UPDATE` where supported, validate all items, mutate stock, cache the success response, and commit. Validation/stock conflicts roll back the operation row and stock changes, so failed reserve attempts are not replay-cached and emit no events.

--- a/migrations/versions/0008_add_reserve_operations.py
+++ b/migrations/versions/0008_add_reserve_operations.py
@@ -1,0 +1,28 @@
+"""Add reserve operations."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0008_add_reserve_operations"
+down_revision = "0007_add_pending_invoice_creation_fields"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "reserve_operations",
+        sa.Column("idempotency_key", sa.String(length=255), nullable=False),
+        sa.Column("request_hash", sa.String(length=64), nullable=False),
+        sa.Column("request_payload", sa.JSON(), nullable=False),
+        sa.Column("response", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint("idempotency_key", name=op.f("pk_reserve_operations")),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("reserve_operations")

--- a/src/api/router.py
+++ b/src/api/router.py
@@ -1,10 +1,11 @@
 from fastapi import APIRouter
 
-from src.api.routes import invoices, products, public_products, skus
+from src.api.routes import invoices, products, public_products, reservations, skus
 
 api_router = APIRouter()
 api_router.include_router(public_products.router)
 api_router.include_router(products.router)
 api_router.include_router(skus.router)
 api_router.include_router(invoices.router)
+api_router.include_router(reservations.router)
 

--- a/src/api/routes/reservations.py
+++ b/src/api/routes/reservations.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 from src.api.deps import unauthorized_response
 from src.core.config import settings
 from src.db.session import get_db
-from src.schemas.reservation import ReservationRead, UnreserveRead
+from src.schemas.reservation import InventoryOrderRead, InventoryReserveRead, ReservationRead, UnreserveRead
 from src.services.reservation_service import (
     IdempotencyConflictError,
     ReservationConflictError,
@@ -25,6 +25,17 @@ def _error(status_code: int, code: str, message: str) -> JSONResponse:
 
 def _invalid_request(message: str) -> JSONResponse:
     return _error(400, "INVALID_REQUEST", message)
+
+
+def _inventory_reserve_conflict(response: dict[str, Any]) -> JSONResponse:
+    return JSONResponse(
+        status_code=409,
+        content={
+            "code": "CONFLICT",
+            "message": "Unable to reserve inventory",
+            "details": {"failed_items": response.get("failed_items", [])},
+        },
+    )
 
 
 def _validate_service_key(service_key: str | None) -> JSONResponse | None:
@@ -72,7 +83,18 @@ def _parse_items(body: dict[str, Any]) -> list[dict[str, int]] | JSONResponse:
     return items
 
 
-async def _parse_reserve_payload(request: Request) -> tuple[str, list[dict[str, int]]] | JSONResponse:
+def _parse_order_id(body: dict[str, Any]) -> str | JSONResponse:
+    order_id = body.get("order_id")
+    if not isinstance(order_id, str) or not order_id.strip():
+        return _invalid_request("order_id is required")
+    return order_id.strip()
+
+
+async def _parse_reserve_payload(
+    request: Request,
+    *,
+    require_order_id: bool = False,
+) -> tuple[str, list[dict[str, int]]] | tuple[str, str, list[dict[str, int]]] | JSONResponse:
     body = await _json_body(request)
     if isinstance(body, JSONResponse):
         return body
@@ -80,10 +102,15 @@ async def _parse_reserve_payload(request: Request) -> tuple[str, list[dict[str, 
     idempotency_key = body.get("idempotency_key")
     if not isinstance(idempotency_key, str) or not idempotency_key.strip():
         return _invalid_request("idempotency_key is required")
+    parsed_order_id = _parse_order_id(body) if require_order_id else None
+    if isinstance(parsed_order_id, JSONResponse):
+        return parsed_order_id
 
     items = _parse_items(body)
     if isinstance(items, JSONResponse):
         return items
+    if parsed_order_id is not None:
+        return idempotency_key.strip(), parsed_order_id, items
     return idempotency_key.strip(), items
 
 
@@ -125,6 +152,33 @@ async def reserve_endpoint(
         return _error(409, "CONFLICT", str(exc))
 
 
+@router.post(
+    "/api/v1/inventory/reserve",
+    response_model=InventoryReserveRead,
+    status_code=status.HTTP_200_OK,
+)
+async def inventory_reserve_endpoint(
+    request: Request,
+    service_key: str | None = Header(default=None, alias="X-Service-Key"),
+    db: Session = Depends(get_db),
+) -> InventoryReserveRead | JSONResponse:
+    auth_error = _validate_service_key(service_key)
+    if auth_error is not None:
+        return auth_error
+
+    payload = await _parse_reserve_payload(request, require_order_id=True)
+    if isinstance(payload, JSONResponse):
+        return payload
+    idempotency_key, order_id, items = payload
+
+    try:
+        return reserve_skus(db, idempotency_key, items, order_id=order_id)
+    except ReservationConflictError as exc:
+        return _inventory_reserve_conflict(exc.response)
+    except IdempotencyConflictError as exc:
+        return _error(409, "CONFLICT", str(exc))
+
+
 @router.post("/api/v1/unreserve", response_model=UnreserveRead, status_code=status.HTTP_200_OK)
 async def unreserve_endpoint(
     request: Request,
@@ -142,5 +196,30 @@ async def unreserve_endpoint(
 
     try:
         return unreserve_skus(db, items)
+    except UnreserveConflictError:
+        return _error(409, "CONFLICT", "Insufficient reserved quantity")
+
+
+@router.post(
+    "/api/v1/inventory/unreserve",
+    response_model=InventoryOrderRead,
+    status_code=status.HTTP_200_OK,
+)
+async def inventory_unreserve_endpoint(
+    request: Request,
+    service_key: str | None = Header(default=None, alias="X-Service-Key"),
+    db: Session = Depends(get_db),
+) -> InventoryOrderRead | JSONResponse:
+    auth_error = _validate_service_key(service_key)
+    if auth_error is not None:
+        return auth_error
+
+    payload = await _parse_unreserve_payload(request)
+    if isinstance(payload, JSONResponse):
+        return payload
+    order_id, items = payload
+
+    try:
+        return unreserve_skus(db, items, order_id=order_id)
     except UnreserveConflictError:
         return _error(409, "CONFLICT", "Insufficient reserved quantity")

--- a/src/api/routes/reservations.py
+++ b/src/api/routes/reservations.py
@@ -1,4 +1,5 @@
 from typing import Any
+import uuid
 
 from fastapi import APIRouter, Depends, Header, Request, status
 from fastapi.responses import JSONResponse
@@ -55,26 +56,30 @@ async def _json_body(request: Request) -> dict[str, Any] | JSONResponse:
     return body
 
 
-def _parse_item(raw_item: Any) -> dict[str, int] | JSONResponse:
+def _parse_item(raw_item: Any) -> dict[str, Any] | JSONResponse:
     if not isinstance(raw_item, dict):
         return _invalid_request("Invalid reservation item")
 
-    sku_id = raw_item.get("sku_id")
+    raw_sku_id = raw_item.get("sku_id")
     quantity = raw_item.get("quantity")
-    if not isinstance(sku_id, int) or isinstance(sku_id, bool) or sku_id <= 0:
-        return _invalid_request("sku_id must be a positive integer")
+    if not isinstance(raw_sku_id, str):
+        return _invalid_request("sku_id must be a valid UUID")
+    try:
+        sku_id = uuid.UUID(raw_sku_id)
+    except ValueError:
+        return _invalid_request("sku_id must be a valid UUID")
     if not isinstance(quantity, int) or isinstance(quantity, bool) or quantity <= 0:
         return _invalid_request("quantity must be > 0")
 
     return {"sku_id": sku_id, "quantity": quantity}
 
 
-def _parse_items(body: dict[str, Any]) -> list[dict[str, int]] | JSONResponse:
+def _parse_items(body: dict[str, Any]) -> list[dict[str, Any]] | JSONResponse:
     raw_items = body.get("items")
     if not isinstance(raw_items, list) or not raw_items:
         return _invalid_request("At least one item is required")
 
-    items: list[dict[str, int]] = []
+    items: list[dict[str, Any]] = []
     for raw_item in raw_items:
         item = _parse_item(raw_item)
         if isinstance(item, JSONResponse):
@@ -94,7 +99,7 @@ async def _parse_reserve_payload(
     request: Request,
     *,
     require_order_id: bool = False,
-) -> tuple[str, list[dict[str, int]]] | tuple[str, str, list[dict[str, int]]] | JSONResponse:
+) -> tuple[str, list[dict[str, Any]]] | tuple[str, str, list[dict[str, Any]]] | JSONResponse:
     body = await _json_body(request)
     if isinstance(body, JSONResponse):
         return body
@@ -114,7 +119,7 @@ async def _parse_reserve_payload(
     return idempotency_key.strip(), items
 
 
-async def _parse_unreserve_payload(request: Request) -> tuple[str, list[dict[str, int]]] | JSONResponse:
+async def _parse_unreserve_payload(request: Request) -> tuple[str, list[dict[str, Any]]] | JSONResponse:
     body = await _json_body(request)
     if isinstance(body, JSONResponse):
         return body

--- a/src/api/routes/reservations.py
+++ b/src/api/routes/reservations.py
@@ -1,0 +1,146 @@
+from typing import Any
+
+from fastapi import APIRouter, Depends, Header, Request, status
+from fastapi.responses import JSONResponse
+from sqlalchemy.orm import Session
+
+from src.api.deps import unauthorized_response
+from src.core.config import settings
+from src.db.session import get_db
+from src.schemas.reservation import ReservationRead, UnreserveRead
+from src.services.reservation_service import (
+    IdempotencyConflictError,
+    ReservationConflictError,
+    UnreserveConflictError,
+    reserve_skus,
+    unreserve_skus,
+)
+
+router = APIRouter(tags=["Reservations"])
+
+
+def _error(status_code: int, code: str, message: str) -> JSONResponse:
+    return JSONResponse(status_code=status_code, content={"code": code, "message": message})
+
+
+def _invalid_request(message: str) -> JSONResponse:
+    return _error(400, "INVALID_REQUEST", message)
+
+
+def _validate_service_key(service_key: str | None) -> JSONResponse | None:
+    if service_key != settings.b2c_to_b2b_key:
+        return unauthorized_response()
+    return None
+
+
+async def _json_body(request: Request) -> dict[str, Any] | JSONResponse:
+    try:
+        body = await request.json()
+    except ValueError:
+        return _invalid_request("Invalid JSON body")
+
+    if not isinstance(body, dict):
+        return _invalid_request("Invalid reservation payload")
+    return body
+
+
+def _parse_item(raw_item: Any) -> dict[str, int] | JSONResponse:
+    if not isinstance(raw_item, dict):
+        return _invalid_request("Invalid reservation item")
+
+    sku_id = raw_item.get("sku_id")
+    quantity = raw_item.get("quantity")
+    if not isinstance(sku_id, int) or isinstance(sku_id, bool) or sku_id <= 0:
+        return _invalid_request("sku_id must be a positive integer")
+    if not isinstance(quantity, int) or isinstance(quantity, bool) or quantity <= 0:
+        return _invalid_request("quantity must be > 0")
+
+    return {"sku_id": sku_id, "quantity": quantity}
+
+
+def _parse_items(body: dict[str, Any]) -> list[dict[str, int]] | JSONResponse:
+    raw_items = body.get("items")
+    if not isinstance(raw_items, list) or not raw_items:
+        return _invalid_request("At least one item is required")
+
+    items: list[dict[str, int]] = []
+    for raw_item in raw_items:
+        item = _parse_item(raw_item)
+        if isinstance(item, JSONResponse):
+            return item
+        items.append(item)
+    return items
+
+
+async def _parse_reserve_payload(request: Request) -> tuple[str, list[dict[str, int]]] | JSONResponse:
+    body = await _json_body(request)
+    if isinstance(body, JSONResponse):
+        return body
+
+    idempotency_key = body.get("idempotency_key")
+    if not isinstance(idempotency_key, str) or not idempotency_key.strip():
+        return _invalid_request("idempotency_key is required")
+
+    items = _parse_items(body)
+    if isinstance(items, JSONResponse):
+        return items
+    return idempotency_key.strip(), items
+
+
+async def _parse_unreserve_payload(request: Request) -> tuple[str, list[dict[str, int]]] | JSONResponse:
+    body = await _json_body(request)
+    if isinstance(body, JSONResponse):
+        return body
+
+    order_id = body.get("order_id")
+    if not isinstance(order_id, str) or not order_id.strip():
+        return _invalid_request("order_id is required")
+
+    items = _parse_items(body)
+    if isinstance(items, JSONResponse):
+        return items
+    return order_id.strip(), items
+
+
+@router.post("/api/v1/reserve", response_model=ReservationRead, status_code=status.HTTP_200_OK)
+async def reserve_endpoint(
+    request: Request,
+    service_key: str | None = Header(default=None, alias="X-Service-Key"),
+    db: Session = Depends(get_db),
+) -> ReservationRead | JSONResponse:
+    auth_error = _validate_service_key(service_key)
+    if auth_error is not None:
+        return auth_error
+
+    payload = await _parse_reserve_payload(request)
+    if isinstance(payload, JSONResponse):
+        return payload
+    idempotency_key, items = payload
+
+    try:
+        return reserve_skus(db, idempotency_key, items)
+    except ReservationConflictError as exc:
+        return JSONResponse(status_code=409, content=exc.response)
+    except IdempotencyConflictError as exc:
+        return _error(409, "CONFLICT", str(exc))
+
+
+@router.post("/api/v1/unreserve", response_model=UnreserveRead, status_code=status.HTTP_200_OK)
+async def unreserve_endpoint(
+    request: Request,
+    service_key: str | None = Header(default=None, alias="X-Service-Key"),
+    db: Session = Depends(get_db),
+) -> UnreserveRead | JSONResponse:
+    auth_error = _validate_service_key(service_key)
+    if auth_error is not None:
+        return auth_error
+
+    payload = await _parse_unreserve_payload(request)
+    if isinstance(payload, JSONResponse):
+        return payload
+    _, items = payload
+
+    try:
+        return unreserve_skus(db, items)
+    except UnreserveConflictError:
+        return _error(409, "CONFLICT", "Insufficient reserved quantity")

--- a/src/db/base.py
+++ b/src/db/base.py
@@ -6,6 +6,7 @@ from src.models import (
     Product,
     ProductCharacteristic,
     ProductImage,
+    ReserveOperation,
     SKU,
     SKUCharacteristic,
 )
@@ -20,5 +21,6 @@ __all__ = [
     "SKUCharacteristic",
     "Invoice",
     "InvoiceItem",
+    "ReserveOperation",
 ]
 

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -2,6 +2,7 @@ from src.models.base import Base
 from src.models.category import Category
 from src.models.invoice import Invoice, InvoiceItem, InvoiceStatus
 from src.models.product import Product, ProductCharacteristic, ProductImage, ProductStatus
+from src.models.reservation import ReserveOperation
 from src.models.sku import SKU, SKUCharacteristic
 
 __all__ = [
@@ -16,5 +17,6 @@ __all__ = [
     "Invoice",
     "InvoiceItem",
     "InvoiceStatus",
+    "ReserveOperation",
 ]
 

--- a/src/models/reservation.py
+++ b/src/models/reservation.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import DateTime, JSON, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.models.base import Base
+
+
+class ReserveOperation(Base):
+    __tablename__ = "reserve_operations"
+
+    idempotency_key: Mapped[str] = mapped_column(String(255), primary_key=True)
+    request_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    request_payload: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+    response: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )

--- a/src/schemas/reservation.py
+++ b/src/schemas/reservation.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from pydantic import Field
 
 from src.schemas.common import APIModel
@@ -28,3 +30,15 @@ class ReservationConflictRead(APIModel):
 
 class UnreserveRead(APIModel):
     ok: bool
+
+
+class InventoryReserveRead(APIModel):
+    order_id: str
+    status: str
+    reserved_at: datetime
+
+
+class InventoryOrderRead(APIModel):
+    order_id: str
+    status: str
+    processed_at: datetime

--- a/src/schemas/reservation.py
+++ b/src/schemas/reservation.py
@@ -1,0 +1,30 @@
+from pydantic import Field
+
+from src.schemas.common import APIModel
+
+
+class ReservationItemRead(APIModel):
+    sku_id: int
+    reserved_quantity: int
+    remaining_stock: int
+
+
+class ReservationRead(APIModel):
+    reserved: bool
+    items: list[ReservationItemRead] = Field(default_factory=list)
+
+
+class FailedReservationItemRead(APIModel):
+    sku_id: int
+    requested: int
+    available: int
+    reason: str
+
+
+class ReservationConflictRead(APIModel):
+    reserved: bool = False
+    failed_items: list[FailedReservationItemRead]
+
+
+class UnreserveRead(APIModel):
+    ok: bool

--- a/src/schemas/reservation.py
+++ b/src/schemas/reservation.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import uuid
 
 from pydantic import Field
 
@@ -6,7 +7,7 @@ from src.schemas.common import APIModel
 
 
 class ReservationItemRead(APIModel):
-    sku_id: int
+    sku_id: uuid.UUID
     reserved_quantity: int
     remaining_stock: int
 
@@ -17,7 +18,7 @@ class ReservationRead(APIModel):
 
 
 class FailedReservationItemRead(APIModel):
-    sku_id: int
+    sku_id: uuid.UUID
     requested: int
     available: int
     reason: str

--- a/src/services/b2c_service.py
+++ b/src/services/b2c_service.py
@@ -35,3 +35,44 @@ def send_product_deleted_event(product_id: int, sku_ids: list[int]) -> None:
         response.raise_for_status()
     except httpx.HTTPError as exc:
         raise B2CSenderError("B2C service unavailable") from exc
+
+
+def build_sku_out_of_stock_event(
+    *,
+    idempotency_key: str,
+    product_id: int,
+    sku_id: int,
+) -> dict[str, str | int]:
+    return {
+        "idempotency_key": idempotency_key,
+        "event": "SKU_OUT_OF_STOCK",
+        "product_id": product_id,
+        "sku_id": sku_id,
+        "date": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+    }
+
+
+def send_sku_out_of_stock_event(
+    *,
+    idempotency_key: str,
+    product_id: int,
+    sku_id: int,
+) -> None:
+    url = f"{settings.b2c_url.rstrip('/')}/api/v1/events/product"
+    headers = {"X-Service-Key": settings.b2b_to_b2c_key}
+    payload = build_sku_out_of_stock_event(
+        idempotency_key=idempotency_key,
+        product_id=product_id,
+        sku_id=sku_id,
+    )
+
+    try:
+        response = httpx.post(
+            url,
+            json=payload,
+            headers=headers,
+            timeout=settings.b2c_timeout_seconds,
+        )
+        response.raise_for_status()
+    except httpx.HTTPError as exc:
+        raise B2CSenderError("B2C service unavailable") from exc

--- a/src/services/b2c_service.py
+++ b/src/services/b2c_service.py
@@ -1,26 +1,29 @@
 from datetime import UTC, datetime
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import httpx
 
 from src.core.config import settings
 
 
+JsonId = UUID | str
+
+
 class B2CSenderError(Exception):
     pass
 
 
-def build_product_deleted_event(product_id: int, sku_ids: list[int]) -> dict[str, str | int | list[str]]:
+def build_product_deleted_event(product_id: JsonId, sku_ids: list[JsonId]) -> dict[str, str | list[str]]:
     return {
         "idempotency_key": str(uuid4()),
         "event": "PRODUCT_DELETED",
-        "product_id": product_id,
+        "product_id": str(product_id),
         "sku_ids": [str(sku_id) for sku_id in sku_ids],
         "date": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
     }
 
 
-def send_product_deleted_event(product_id: int, sku_ids: list[int]) -> None:
+def send_product_deleted_event(product_id: JsonId, sku_ids: list[JsonId]) -> None:
     url = f"{settings.b2c_url.rstrip('/')}/api/v1/events/product"
     headers = {"X-Service-Key": settings.b2b_to_b2c_key}
     payload = build_product_deleted_event(product_id, sku_ids)
@@ -40,14 +43,14 @@ def send_product_deleted_event(product_id: int, sku_ids: list[int]) -> None:
 def build_sku_out_of_stock_event(
     *,
     idempotency_key: str,
-    product_id: int,
-    sku_id: int,
-) -> dict[str, str | int]:
+    product_id: JsonId,
+    sku_id: JsonId,
+) -> dict[str, str]:
     return {
         "idempotency_key": idempotency_key,
         "event": "SKU_OUT_OF_STOCK",
-        "product_id": product_id,
-        "sku_id": sku_id,
+        "product_id": str(product_id),
+        "sku_id": str(sku_id),
         "date": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
     }
 
@@ -55,8 +58,8 @@ def build_sku_out_of_stock_event(
 def send_sku_out_of_stock_event(
     *,
     idempotency_key: str,
-    product_id: int,
-    sku_id: int,
+    product_id: JsonId,
+    sku_id: JsonId,
 ) -> None:
     url = f"{settings.b2c_url.rstrip('/')}/api/v1/events/product"
     headers = {"X-Service-Key": settings.b2b_to_b2c_key}

--- a/src/services/reservation_service.py
+++ b/src/services/reservation_service.py
@@ -1,0 +1,193 @@
+import hashlib
+import json
+import logging
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session, selectinload
+
+from src.models import ProductStatus, ReserveOperation, SKU
+from src.services.b2c_service import send_sku_out_of_stock_event
+
+logger = logging.getLogger(__name__)
+
+
+class ReservationConflictError(Exception):
+    def __init__(self, response: dict[str, Any]) -> None:
+        self.response = response
+        super().__init__("Reservation conflict")
+
+
+class IdempotencyConflictError(Exception):
+    pass
+
+
+class UnreserveConflictError(Exception):
+    pass
+
+
+def _normalized_items(items: list[dict[str, int]]) -> list[dict[str, int]]:
+    quantities_by_sku: dict[int, int] = {}
+    for item in items:
+        sku_id = int(item["sku_id"])
+        quantities_by_sku[sku_id] = quantities_by_sku.get(sku_id, 0) + int(item["quantity"])
+
+    return [
+        {"sku_id": sku_id, "quantity": quantity}
+        for sku_id, quantity in sorted(quantities_by_sku.items())
+    ]
+
+
+def _normalized_reserve_payload(idempotency_key: str, items: list[dict[str, int]]) -> dict[str, Any]:
+    return {
+        "idempotency_key": idempotency_key,
+        "items": _normalized_items(items),
+    }
+
+
+def _request_hash(payload: dict[str, Any]) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _cached_response_or_conflict(operation: ReserveOperation, request_hash: str) -> dict[str, Any]:
+    if operation.request_hash != request_hash:
+        raise IdempotencyConflictError("idempotency_key was already used with a different payload")
+    return operation.response
+
+
+def _lock_skus(db: Session, sku_ids: list[int]) -> dict[int, SKU]:
+    skus = db.scalars(
+        select(SKU)
+        .options(selectinload(SKU.product))
+        .where(SKU.id.in_(sku_ids))
+        .with_for_update()
+    ).all()
+    return {sku.id: sku for sku in skus}
+
+
+def _is_visible_catalog_sku(sku: SKU | None) -> bool:
+    if sku is None or sku.product is None:
+        return False
+    return sku.product.status == ProductStatus.MODERATED and sku.product.deleted is False
+
+
+def _reserve_conflicts(items: list[dict[str, int]], sku_map: dict[int, SKU]) -> list[dict[str, Any]]:
+    failed_items: list[dict[str, Any]] = []
+    for item in items:
+        sku_id = item["sku_id"]
+        requested = item["quantity"]
+        sku = sku_map.get(sku_id)
+
+        if not _is_visible_catalog_sku(sku):
+            failed_items.append(
+                {
+                    "sku_id": sku_id,
+                    "requested": requested,
+                    "available": 0,
+                    "reason": "OUT_OF_STOCK",
+                }
+            )
+            continue
+
+        available = sku.active_quantity
+        if available < requested:
+            failed_items.append(
+                {
+                    "sku_id": sku_id,
+                    "requested": requested,
+                    "available": available,
+                    "reason": "OUT_OF_STOCK" if available == 0 else "INSUFFICIENT_STOCK",
+                }
+            )
+
+    return failed_items
+
+
+def reserve_skus(db: Session, idempotency_key: str, items: list[dict[str, int]]) -> dict[str, Any]:
+    normalized_payload = _normalized_reserve_payload(idempotency_key, items)
+    normalized_items = normalized_payload["items"]
+    request_hash = _request_hash(normalized_payload)
+
+    existing_operation = db.get(ReserveOperation, idempotency_key)
+    if existing_operation is not None:
+        return _cached_response_or_conflict(existing_operation, request_hash)
+
+    operation = ReserveOperation(
+        idempotency_key=idempotency_key,
+        request_hash=request_hash,
+        request_payload=normalized_payload,
+        response={},
+    )
+    db.add(operation)
+
+    try:
+        db.flush()
+    except IntegrityError:
+        db.rollback()
+        existing_operation = db.get(ReserveOperation, idempotency_key)
+        if existing_operation is None:
+            raise IdempotencyConflictError("idempotency_key is currently being processed")
+        return _cached_response_or_conflict(existing_operation, request_hash)
+
+    sku_ids = [item["sku_id"] for item in normalized_items]
+    sku_map = _lock_skus(db, sku_ids)
+    failed_items = _reserve_conflicts(normalized_items, sku_map)
+    if failed_items:
+        db.rollback()
+        raise ReservationConflictError({"reserved": False, "failed_items": failed_items})
+
+    out_of_stock_events: list[tuple[int, int]] = []
+    response_items: list[dict[str, int]] = []
+    for item in normalized_items:
+        sku = sku_map[item["sku_id"]]
+        quantity = item["quantity"]
+        sku.active_quantity -= quantity
+        sku.reserved_quantity += quantity
+        if sku.active_quantity == 0:
+            out_of_stock_events.append((sku.product_id, sku.id))
+        response_items.append(
+            {
+                "sku_id": sku.id,
+                "reserved_quantity": quantity,
+                "remaining_stock": sku.active_quantity,
+            }
+        )
+
+    response: dict[str, Any] = {"reserved": True, "items": response_items}
+    operation.response = response
+    db.commit()
+
+    for product_id, sku_id in out_of_stock_events:
+        try:
+            send_sku_out_of_stock_event(
+                idempotency_key=idempotency_key,
+                product_id=product_id,
+                sku_id=sku_id,
+            )
+        except Exception:
+            logger.exception("Failed to send SKU_OUT_OF_STOCK event to B2C")
+
+    return response
+
+
+def unreserve_skus(db: Session, items: list[dict[str, int]]) -> dict[str, bool]:
+    normalized_items = _normalized_items(items)
+    sku_ids = [item["sku_id"] for item in normalized_items]
+    sku_map = _lock_skus(db, sku_ids)
+
+    for item in normalized_items:
+        sku = sku_map.get(item["sku_id"])
+        if sku is None or sku.reserved_quantity < item["quantity"]:
+            db.rollback()
+            raise UnreserveConflictError("Insufficient reserved quantity")
+
+    for item in normalized_items:
+        sku = sku_map[item["sku_id"]]
+        quantity = item["quantity"]
+        sku.active_quantity += quantity
+        sku.reserved_quantity -= quantity
+
+    db.commit()
+    return {"ok": True}

--- a/src/services/reservation_service.py
+++ b/src/services/reservation_service.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import logging
+import uuid
 from datetime import datetime, timezone
 from typing import Any
 
@@ -28,26 +29,29 @@ class UnreserveConflictError(Exception):
     pass
 
 
-def _normalized_items(items: list[dict[str, int]]) -> list[dict[str, int]]:
-    quantities_by_sku: dict[int, int] = {}
+def _normalized_items(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    quantities_by_sku: dict[uuid.UUID, int] = {}
     for item in items:
-        sku_id = int(item["sku_id"])
+        sku_id = item["sku_id"]
         quantities_by_sku[sku_id] = quantities_by_sku.get(sku_id, 0) + int(item["quantity"])
 
     return [
         {"sku_id": sku_id, "quantity": quantity}
-        for sku_id, quantity in sorted(quantities_by_sku.items())
+        for sku_id, quantity in sorted(quantities_by_sku.items(), key=lambda value: str(value[0]))
     ]
 
 
 def _normalized_reserve_payload(
     idempotency_key: str,
-    items: list[dict[str, int]],
+    items: list[dict[str, Any]],
     order_id: str | None = None,
 ) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "idempotency_key": idempotency_key,
-        "items": _normalized_items(items),
+        "items": [
+            {"sku_id": str(item["sku_id"]), "quantity": item["quantity"]}
+            for item in items
+        ],
     }
     if order_id is not None:
         payload["order_id"] = order_id
@@ -85,7 +89,7 @@ def _cached_response_or_conflict(
     return operation.response
 
 
-def _lock_skus(db: Session, sku_ids: list[int]) -> dict[int, SKU]:
+def _lock_skus(db: Session, sku_ids: list[uuid.UUID]) -> dict[uuid.UUID, SKU]:
     skus = db.scalars(
         select(SKU)
         .options(selectinload(SKU.product))
@@ -101,7 +105,7 @@ def _is_visible_catalog_sku(sku: SKU | None) -> bool:
     return sku.product.status == ProductStatus.MODERATED and sku.product.deleted is False
 
 
-def _reserve_conflicts(items: list[dict[str, int]], sku_map: dict[int, SKU]) -> list[dict[str, Any]]:
+def _reserve_conflicts(items: list[dict[str, Any]], sku_map: dict[uuid.UUID, SKU]) -> list[dict[str, Any]]:
     failed_items: list[dict[str, Any]] = []
     for item in items:
         sku_id = item["sku_id"]
@@ -111,7 +115,7 @@ def _reserve_conflicts(items: list[dict[str, int]], sku_map: dict[int, SKU]) -> 
         if not _is_visible_catalog_sku(sku):
             failed_items.append(
                 {
-                    "sku_id": sku_id,
+                    "sku_id": str(sku_id),
                     "requested": requested,
                     "available": 0,
                     "reason": "OUT_OF_STOCK",
@@ -123,7 +127,7 @@ def _reserve_conflicts(items: list[dict[str, int]], sku_map: dict[int, SKU]) -> 
         if available < requested:
             failed_items.append(
                 {
-                    "sku_id": sku_id,
+                    "sku_id": str(sku_id),
                     "requested": requested,
                     "available": available,
                     "reason": "OUT_OF_STOCK" if available == 0 else "INSUFFICIENT_STOCK",
@@ -136,11 +140,11 @@ def _reserve_conflicts(items: list[dict[str, int]], sku_map: dict[int, SKU]) -> 
 def reserve_skus(
     db: Session,
     idempotency_key: str,
-    items: list[dict[str, int]],
+    items: list[dict[str, Any]],
     order_id: str | None = None,
 ) -> dict[str, Any]:
-    normalized_payload = _normalized_reserve_payload(idempotency_key, items, order_id)
-    normalized_items = normalized_payload["items"]
+    normalized_items = _normalized_items(items)
+    normalized_payload = _normalized_reserve_payload(idempotency_key, normalized_items, order_id)
     request_hash = _request_hash(normalized_payload)
 
     existing_operation = db.get(ReserveOperation, idempotency_key)
@@ -171,8 +175,8 @@ def reserve_skus(
         db.rollback()
         raise ReservationConflictError({"reserved": False, "failed_items": failed_items})
 
-    out_of_stock_events: list[tuple[int, int]] = []
-    response_items: list[dict[str, int]] = []
+    out_of_stock_events: list[tuple[uuid.UUID, uuid.UUID]] = []
+    response_items: list[dict[str, Any]] = []
     for item in normalized_items:
         sku = sku_map[item["sku_id"]]
         quantity = item["quantity"]
@@ -182,7 +186,7 @@ def reserve_skus(
             out_of_stock_events.append((sku.product_id, sku.id))
         response_items.append(
             {
-                "sku_id": sku.id,
+                "sku_id": str(sku.id),
                 "reserved_quantity": quantity,
                 "remaining_stock": sku.active_quantity,
             }
@@ -211,7 +215,7 @@ def reserve_skus(
 
 def unreserve_skus(
     db: Session,
-    items: list[dict[str, int]],
+    items: list[dict[str, Any]],
     order_id: str | None = None,
 ) -> dict[str, Any]:
     normalized_items = _normalized_items(items)

--- a/src/services/reservation_service.py
+++ b/src/services/reservation_service.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import logging
+from datetime import datetime, timezone
 from typing import Any
 
 from sqlalchemy import select
@@ -39,11 +40,18 @@ def _normalized_items(items: list[dict[str, int]]) -> list[dict[str, int]]:
     ]
 
 
-def _normalized_reserve_payload(idempotency_key: str, items: list[dict[str, int]]) -> dict[str, Any]:
-    return {
+def _normalized_reserve_payload(
+    idempotency_key: str,
+    items: list[dict[str, int]],
+    order_id: str | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
         "idempotency_key": idempotency_key,
         "items": _normalized_items(items),
     }
+    if order_id is not None:
+        payload["order_id"] = order_id
+    return payload
 
 
 def _request_hash(payload: dict[str, Any]) -> str:
@@ -51,9 +59,29 @@ def _request_hash(payload: dict[str, Any]) -> str:
     return hashlib.sha256(raw.encode("utf-8")).hexdigest()
 
 
-def _cached_response_or_conflict(operation: ReserveOperation, request_hash: str) -> dict[str, Any]:
+def _timestamp(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.isoformat()
+
+
+def _canonical_reserve_response(operation: ReserveOperation, order_id: str) -> dict[str, Any]:
+    return {
+        "order_id": order_id,
+        "status": "RESERVED",
+        "reserved_at": _timestamp(operation.created_at),
+    }
+
+
+def _cached_response_or_conflict(
+    operation: ReserveOperation,
+    request_hash: str,
+    order_id: str | None = None,
+) -> dict[str, Any]:
     if operation.request_hash != request_hash:
         raise IdempotencyConflictError("idempotency_key was already used with a different payload")
+    if order_id is not None:
+        return _canonical_reserve_response(operation, order_id)
     return operation.response
 
 
@@ -105,14 +133,19 @@ def _reserve_conflicts(items: list[dict[str, int]], sku_map: dict[int, SKU]) -> 
     return failed_items
 
 
-def reserve_skus(db: Session, idempotency_key: str, items: list[dict[str, int]]) -> dict[str, Any]:
-    normalized_payload = _normalized_reserve_payload(idempotency_key, items)
+def reserve_skus(
+    db: Session,
+    idempotency_key: str,
+    items: list[dict[str, int]],
+    order_id: str | None = None,
+) -> dict[str, Any]:
+    normalized_payload = _normalized_reserve_payload(idempotency_key, items, order_id)
     normalized_items = normalized_payload["items"]
     request_hash = _request_hash(normalized_payload)
 
     existing_operation = db.get(ReserveOperation, idempotency_key)
     if existing_operation is not None:
-        return _cached_response_or_conflict(existing_operation, request_hash)
+        return _cached_response_or_conflict(existing_operation, request_hash, order_id)
 
     operation = ReserveOperation(
         idempotency_key=idempotency_key,
@@ -129,7 +162,7 @@ def reserve_skus(db: Session, idempotency_key: str, items: list[dict[str, int]])
         existing_operation = db.get(ReserveOperation, idempotency_key)
         if existing_operation is None:
             raise IdempotencyConflictError("idempotency_key is currently being processed")
-        return _cached_response_or_conflict(existing_operation, request_hash)
+        return _cached_response_or_conflict(existing_operation, request_hash, order_id)
 
     sku_ids = [item["sku_id"] for item in normalized_items]
     sku_map = _lock_skus(db, sku_ids)
@@ -158,6 +191,8 @@ def reserve_skus(db: Session, idempotency_key: str, items: list[dict[str, int]])
     response: dict[str, Any] = {"reserved": True, "items": response_items}
     operation.response = response
     db.commit()
+    if order_id is not None:
+        db.refresh(operation)
 
     for product_id, sku_id in out_of_stock_events:
         try:
@@ -169,10 +204,16 @@ def reserve_skus(db: Session, idempotency_key: str, items: list[dict[str, int]])
         except Exception:
             logger.exception("Failed to send SKU_OUT_OF_STOCK event to B2C")
 
+    if order_id is not None:
+        return _canonical_reserve_response(operation, order_id)
     return response
 
 
-def unreserve_skus(db: Session, items: list[dict[str, int]]) -> dict[str, bool]:
+def unreserve_skus(
+    db: Session,
+    items: list[dict[str, int]],
+    order_id: str | None = None,
+) -> dict[str, Any]:
     normalized_items = _normalized_items(items)
     sku_ids = [item["sku_id"] for item in normalized_items]
     sku_map = _lock_skus(db, sku_ids)
@@ -190,4 +231,10 @@ def unreserve_skus(db: Session, items: list[dict[str, int]]) -> dict[str, bool]:
         sku.reserved_quantity -= quantity
 
     db.commit()
+    if order_id is not None:
+        return {
+            "order_id": order_id,
+            "status": "UNRESERVED",
+            "processed_at": _timestamp(datetime.now(timezone.utc)),
+        }
     return {"ok": True}

--- a/tests/api/test_reservations.py
+++ b/tests/api/test_reservations.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
@@ -71,10 +71,18 @@ def reserve_operation_count(db_session: Session) -> int:
     return db_session.scalar(select(func.count(ReserveOperation.idempotency_key))) or 0
 
 
+def json_sku_id(sku: SKU) -> str:
+    return str(sku.id)
+
+
+def sort_by_sku_id(items: list[dict]) -> list[dict]:
+    return sorted(items, key=lambda item: item["sku_id"])
+
+
 def reserve_payload(idempotency_key: str, sku: SKU, quantity: int = 2) -> dict:
     return {
         "idempotency_key": idempotency_key,
-        "items": [{"sku_id": sku.id, "quantity": quantity}],
+        "items": [{"sku_id": json_sku_id(sku), "quantity": quantity}],
     }
 
 
@@ -82,20 +90,20 @@ def inventory_reserve_payload(order_id: str, idempotency_key: str, sku: SKU, qua
     return {
         "idempotency_key": idempotency_key,
         "order_id": order_id,
-        "items": [{"sku_id": sku.id, "quantity": quantity}],
+        "items": [{"sku_id": json_sku_id(sku), "quantity": quantity}],
     }
 
 
 def unreserve_payload(order_id: str, sku: SKU, quantity: int = 2) -> dict:
     return {
         "order_id": order_id,
-        "items": [{"sku_id": sku.id, "quantity": quantity}],
+        "items": [{"sku_id": json_sku_id(sku), "quantity": quantity}],
     }
 
 
 def assert_sku_quantities(
     db_session: Session,
-    sku_id: int,
+    sku_id: UUID,
     *,
     active_quantity: int,
     reserved_quantity: int,
@@ -122,8 +130,8 @@ def test_reserve_all_skus_succeeds(client, db_session: Session, category_factory
         json={
             "idempotency_key": "reserve-all-skus",
             "items": [
-                {"sku_id": first_sku.id, "quantity": 2},
-                {"sku_id": second_sku.id, "quantity": 1},
+                {"sku_id": json_sku_id(first_sku), "quantity": 2},
+                {"sku_id": json_sku_id(second_sku), "quantity": 1},
             ],
         },
         headers=service_headers(),
@@ -132,10 +140,10 @@ def test_reserve_all_skus_succeeds(client, db_session: Session, category_factory
     assert response.status_code == 200
     assert response.json() == {
         "reserved": True,
-        "items": [
-            {"sku_id": first_sku.id, "reserved_quantity": 2, "remaining_stock": 3},
-            {"sku_id": second_sku.id, "reserved_quantity": 1, "remaining_stock": 2},
-        ],
+        "items": sort_by_sku_id([
+            {"sku_id": json_sku_id(first_sku), "reserved_quantity": 2, "remaining_stock": 3},
+            {"sku_id": json_sku_id(second_sku), "reserved_quantity": 1, "remaining_stock": 2},
+        ]),
     }
     assert_sku_quantities(db_session, first_sku.id, active_quantity=3, reserved_quantity=3)
     assert_sku_quantities(db_session, second_sku.id, active_quantity=2, reserved_quantity=1)
@@ -239,8 +247,8 @@ def test_inventory_reserve_conflict_returns_error_with_failed_items_details_and_
             "idempotency_key": str(uuid4()),
             "order_id": str(uuid4()),
             "items": [
-                {"sku_id": enough_sku.id, "quantity": 2},
-                {"sku_id": low_sku.id, "quantity": 2},
+                {"sku_id": json_sku_id(enough_sku), "quantity": 2},
+                {"sku_id": json_sku_id(low_sku), "quantity": 2},
             ],
         },
         headers=service_headers(),
@@ -253,7 +261,7 @@ def test_inventory_reserve_conflict_returns_error_with_failed_items_details_and_
         "details": {
             "failed_items": [
                 {
-                    "sku_id": low_sku.id,
+                    "sku_id": json_sku_id(low_sku),
                     "requested": 2,
                     "available": 1,
                     "reason": "INSUFFICIENT_STOCK",
@@ -307,7 +315,7 @@ def test_legacy_reserve_and_unreserve_routes_keep_response_shapes(
     assert reserve_response.status_code == 200
     assert reserve_response.json() == {
         "reserved": True,
-        "items": [{"sku_id": sku.id, "reserved_quantity": 2, "remaining_stock": 3}],
+        "items": [{"sku_id": json_sku_id(sku), "reserved_quantity": 2, "remaining_stock": 3}],
     }
     assert unreserve_response.status_code == 200
     assert unreserve_response.json() == {"ok": True}
@@ -328,8 +336,8 @@ def test_partial_insufficient_stock_returns_409_all_rollback(
         json={
             "idempotency_key": "partial-insufficient",
             "items": [
-                {"sku_id": enough_sku.id, "quantity": 2},
-                {"sku_id": low_sku.id, "quantity": 2},
+                {"sku_id": json_sku_id(enough_sku), "quantity": 2},
+                {"sku_id": json_sku_id(low_sku), "quantity": 2},
             ],
         },
         headers=service_headers(),
@@ -340,7 +348,7 @@ def test_partial_insufficient_stock_returns_409_all_rollback(
         "reserved": False,
         "failed_items": [
             {
-                "sku_id": low_sku.id,
+                "sku_id": json_sku_id(low_sku),
                 "requested": 2,
                 "available": 1,
                 "reason": "INSUFFICIENT_STOCK",
@@ -408,8 +416,8 @@ def test_sku_out_of_stock_event_emitted(
     assert request["timeout"] == settings.b2c_timeout_seconds
     assert request["json"]["idempotency_key"] == "sku-out-of-stock"
     assert request["json"]["event"] == "SKU_OUT_OF_STOCK"
-    assert request["json"]["product_id"] == product.id
-    assert request["json"]["sku_id"] == sku.id
+    assert request["json"]["product_id"] == str(product.id)
+    assert request["json"]["sku_id"] == json_sku_id(sku)
     assert request["json"]["date"]
 
 
@@ -437,15 +445,15 @@ def test_hidden_deleted_and_missing_skus_return_out_of_stock(
     deleted_product = create_product(db_session, category_factory, deleted=True)
     hidden_sku = create_sku(db_session, hidden_product, active_quantity=7, reserved_quantity=0)
     deleted_sku = create_sku(db_session, deleted_product, active_quantity=8, reserved_quantity=0)
-    missing_sku_id = 999999
+    missing_sku_id = str(uuid4())
 
     response = client.post(
         "/api/v1/reserve",
         json={
             "idempotency_key": "hidden-and-missing",
             "items": [
-                {"sku_id": hidden_sku.id, "quantity": 1},
-                {"sku_id": deleted_sku.id, "quantity": 1},
+                {"sku_id": json_sku_id(hidden_sku), "quantity": 1},
+                {"sku_id": json_sku_id(deleted_sku), "quantity": 1},
                 {"sku_id": missing_sku_id, "quantity": 1},
             ],
         },
@@ -453,28 +461,29 @@ def test_hidden_deleted_and_missing_skus_return_out_of_stock(
     )
 
     assert response.status_code == 409
+    expected_failed_items = [
+        {
+            "sku_id": json_sku_id(hidden_sku),
+            "requested": 1,
+            "available": 0,
+            "reason": "OUT_OF_STOCK",
+        },
+        {
+            "sku_id": json_sku_id(deleted_sku),
+            "requested": 1,
+            "available": 0,
+            "reason": "OUT_OF_STOCK",
+        },
+        {
+            "sku_id": missing_sku_id,
+            "requested": 1,
+            "available": 0,
+            "reason": "OUT_OF_STOCK",
+        },
+    ]
     assert response.json() == {
         "reserved": False,
-        "failed_items": [
-            {
-                "sku_id": hidden_sku.id,
-                "requested": 1,
-                "available": 0,
-                "reason": "OUT_OF_STOCK",
-            },
-            {
-                "sku_id": deleted_sku.id,
-                "requested": 1,
-                "available": 0,
-                "reason": "OUT_OF_STOCK",
-            },
-            {
-                "sku_id": missing_sku_id,
-                "requested": 1,
-                "available": 0,
-                "reason": "OUT_OF_STOCK",
-            },
-        ],
+        "failed_items": sort_by_sku_id(expected_failed_items),
     }
     assert_sku_quantities(db_session, hidden_sku.id, active_quantity=7, reserved_quantity=0)
     assert_sku_quantities(db_session, deleted_sku.id, active_quantity=8, reserved_quantity=0)
@@ -530,8 +539,8 @@ def test_reserve_rollback_does_not_emit_sku_out_of_stock(
         json={
             "idempotency_key": "rollback-no-event",
             "items": [
-                {"sku_id": enough_sku.id, "quantity": 1},
-                {"sku_id": low_sku.id, "quantity": 2},
+                {"sku_id": json_sku_id(enough_sku), "quantity": 1},
+                {"sku_id": json_sku_id(low_sku), "quantity": 2},
             ],
         },
         headers=service_headers(),

--- a/tests/api/test_reservations.py
+++ b/tests/api/test_reservations.py
@@ -1,3 +1,6 @@
+from datetime import datetime
+from uuid import uuid4
+
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
@@ -75,6 +78,14 @@ def reserve_payload(idempotency_key: str, sku: SKU, quantity: int = 2) -> dict:
     }
 
 
+def inventory_reserve_payload(order_id: str, idempotency_key: str, sku: SKU, quantity: int = 2) -> dict:
+    return {
+        "idempotency_key": idempotency_key,
+        "order_id": order_id,
+        "items": [{"sku_id": sku.id, "quantity": quantity}],
+    }
+
+
 def unreserve_payload(order_id: str, sku: SKU, quantity: int = 2) -> dict:
     return {
         "order_id": order_id,
@@ -129,6 +140,178 @@ def test_reserve_all_skus_succeeds(client, db_session: Session, category_factory
     assert_sku_quantities(db_session, first_sku.id, active_quantity=3, reserved_quantity=3)
     assert_sku_quantities(db_session, second_sku.id, active_quantity=2, reserved_quantity=1)
     assert reserve_operation_count(db_session) == 1
+
+
+def test_inventory_reserve_returns_openapi_response(client, db_session: Session, category_factory):
+    product = create_product(db_session, category_factory)
+    sku = create_sku(db_session, product, active_quantity=5, reserved_quantity=1)
+    order_id = str(uuid4())
+
+    response = client.post(
+        "/api/v1/inventory/reserve",
+        json=inventory_reserve_payload(order_id, str(uuid4()), sku, 2),
+        headers=service_headers(),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["order_id"] == order_id
+    assert body["status"] == "RESERVED"
+    assert datetime.fromisoformat(body["reserved_at"])
+    assert_sku_quantities(db_session, sku.id, active_quantity=3, reserved_quantity=3)
+
+
+def test_inventory_reserve_requires_order_id(client, db_session: Session, category_factory):
+    product = create_product(db_session, category_factory)
+    sku = create_sku(db_session, product, active_quantity=5)
+
+    response = client.post(
+        "/api/v1/inventory/reserve",
+        json=reserve_payload(str(uuid4()), sku, 2),
+        headers=service_headers(),
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"code": "INVALID_REQUEST", "message": "order_id is required"}
+    assert_sku_quantities(db_session, sku.id, active_quantity=5, reserved_quantity=0)
+
+
+def test_inventory_reserve_idempotent_replay_returns_same_reserved_at_without_double_deduction(
+    client,
+    db_session: Session,
+    category_factory,
+):
+    product = create_product(db_session, category_factory)
+    sku = create_sku(db_session, product, active_quantity=5)
+    payload = inventory_reserve_payload(str(uuid4()), str(uuid4()), sku, 2)
+
+    first_response = client.post("/api/v1/inventory/reserve", json=payload, headers=service_headers())
+    second_response = client.post("/api/v1/inventory/reserve", json=payload, headers=service_headers())
+
+    assert first_response.status_code == 200
+    assert second_response.status_code == 200
+    assert second_response.json() == first_response.json()
+    assert_sku_quantities(db_session, sku.id, active_quantity=3, reserved_quantity=2)
+    assert reserve_operation_count(db_session) == 1
+
+
+def test_inventory_reserve_same_key_different_order_id_returns_409(
+    client,
+    db_session: Session,
+    category_factory,
+):
+    product = create_product(db_session, category_factory)
+    sku = create_sku(db_session, product, active_quantity=5)
+    idempotency_key = str(uuid4())
+
+    first_response = client.post(
+        "/api/v1/inventory/reserve",
+        json=inventory_reserve_payload(str(uuid4()), idempotency_key, sku, 1),
+        headers=service_headers(),
+    )
+    second_response = client.post(
+        "/api/v1/inventory/reserve",
+        json=inventory_reserve_payload(str(uuid4()), idempotency_key, sku, 1),
+        headers=service_headers(),
+    )
+
+    assert first_response.status_code == 200
+    assert second_response.status_code == 409
+    assert second_response.json() == {
+        "code": "CONFLICT",
+        "message": "idempotency_key was already used with a different payload",
+    }
+    assert_sku_quantities(db_session, sku.id, active_quantity=4, reserved_quantity=1)
+
+
+def test_inventory_reserve_conflict_returns_error_with_failed_items_details_and_rolls_back(
+    client,
+    db_session: Session,
+    category_factory,
+):
+    product = create_product(db_session, category_factory)
+    enough_sku = create_sku(db_session, product, active_quantity=5, reserved_quantity=1)
+    low_sku = create_sku(db_session, product, name="256GB Black", active_quantity=1)
+
+    response = client.post(
+        "/api/v1/inventory/reserve",
+        json={
+            "idempotency_key": str(uuid4()),
+            "order_id": str(uuid4()),
+            "items": [
+                {"sku_id": enough_sku.id, "quantity": 2},
+                {"sku_id": low_sku.id, "quantity": 2},
+            ],
+        },
+        headers=service_headers(),
+    )
+
+    assert response.status_code == 409
+    assert response.json() == {
+        "code": "CONFLICT",
+        "message": "Unable to reserve inventory",
+        "details": {
+            "failed_items": [
+                {
+                    "sku_id": low_sku.id,
+                    "requested": 2,
+                    "available": 1,
+                    "reason": "INSUFFICIENT_STOCK",
+                }
+            ]
+        },
+    }
+    assert_sku_quantities(db_session, enough_sku.id, active_quantity=5, reserved_quantity=1)
+    assert_sku_quantities(db_session, low_sku.id, active_quantity=1, reserved_quantity=0)
+    assert reserve_operation_count(db_session) == 0
+
+
+def test_inventory_unreserve_returns_openapi_response(client, db_session: Session, category_factory):
+    product = create_product(db_session, category_factory)
+    sku = create_sku(db_session, product, active_quantity=3, reserved_quantity=5)
+    order_id = str(uuid4())
+
+    response = client.post(
+        "/api/v1/inventory/unreserve",
+        json=unreserve_payload(order_id, sku, 2),
+        headers=service_headers(),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["order_id"] == order_id
+    assert body["status"] == "UNRESERVED"
+    assert datetime.fromisoformat(body["processed_at"])
+    assert_sku_quantities(db_session, sku.id, active_quantity=5, reserved_quantity=3)
+
+
+def test_legacy_reserve_and_unreserve_routes_keep_response_shapes(
+    client,
+    db_session: Session,
+    category_factory,
+):
+    product = create_product(db_session, category_factory)
+    sku = create_sku(db_session, product, active_quantity=5)
+
+    reserve_response = client.post(
+        "/api/v1/reserve",
+        json=reserve_payload("legacy-shape", sku, 2),
+        headers=service_headers(),
+    )
+    unreserve_response = client.post(
+        "/api/v1/unreserve",
+        json=unreserve_payload("legacy-order", sku, 1),
+        headers=service_headers(),
+    )
+
+    assert reserve_response.status_code == 200
+    assert reserve_response.json() == {
+        "reserved": True,
+        "items": [{"sku_id": sku.id, "reserved_quantity": 2, "remaining_stock": 3}],
+    }
+    assert unreserve_response.status_code == 200
+    assert unreserve_response.json() == {"ok": True}
+    assert_sku_quantities(db_session, sku.id, active_quantity=4, reserved_quantity=1)
 
 
 def test_partial_insufficient_stock_returns_409_all_rollback(

--- a/tests/api/test_reservations.py
+++ b/tests/api/test_reservations.py
@@ -1,0 +1,434 @@
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from src.core.config import settings
+from src.models import Product, ProductImage, ProductStatus, ReserveOperation, SKU
+
+
+SELLER_ID = "c3d4e5f6-a7b8-9012-cdef-123456789012"
+
+
+class FakeB2CResponse:
+    def raise_for_status(self) -> None:
+        return None
+
+
+def service_headers() -> dict[str, str]:
+    return {"X-Service-Key": settings.b2c_to_b2b_key}
+
+
+def create_product(
+    db_session: Session,
+    category_factory,
+    *,
+    status: ProductStatus = ProductStatus.MODERATED,
+    deleted: bool = False,
+) -> Product:
+    category = category_factory()
+    product = Product(
+        title="iPhone 15 Pro Max",
+        description="Flagship smartphone",
+        seller_id=SELLER_ID,
+        category_id=category.id,
+        status=status,
+        deleted=deleted,
+    )
+    product.images = [ProductImage(url="/s3/iphone15-front.jpg", ordering=0)]
+    db_session.add(product)
+    db_session.commit()
+    db_session.refresh(product)
+    return product
+
+
+def create_sku(
+    db_session: Session,
+    product: Product,
+    *,
+    name: str = "128GB Black",
+    active_quantity: int = 0,
+    reserved_quantity: int = 0,
+) -> SKU:
+    sku = SKU(
+        product_id=product.id,
+        name=name,
+        price=9999000,
+        cost_price=7000000,
+        discount=0,
+        image="/s3/iphone15-black-128.jpg",
+        active_quantity=active_quantity,
+        reserved_quantity=reserved_quantity,
+    )
+    db_session.add(sku)
+    db_session.commit()
+    db_session.refresh(sku)
+    return sku
+
+
+def reserve_operation_count(db_session: Session) -> int:
+    return db_session.scalar(select(func.count(ReserveOperation.idempotency_key))) or 0
+
+
+def reserve_payload(idempotency_key: str, sku: SKU, quantity: int = 2) -> dict:
+    return {
+        "idempotency_key": idempotency_key,
+        "items": [{"sku_id": sku.id, "quantity": quantity}],
+    }
+
+
+def unreserve_payload(order_id: str, sku: SKU, quantity: int = 2) -> dict:
+    return {
+        "order_id": order_id,
+        "items": [{"sku_id": sku.id, "quantity": quantity}],
+    }
+
+
+def assert_sku_quantities(
+    db_session: Session,
+    sku_id: int,
+    *,
+    active_quantity: int,
+    reserved_quantity: int,
+) -> None:
+    db_session.expire_all()
+    sku = db_session.get(SKU, sku_id)
+    assert sku.active_quantity == active_quantity
+    assert sku.reserved_quantity == reserved_quantity
+
+
+def test_reserve_all_skus_succeeds(client, db_session: Session, category_factory):
+    product = create_product(db_session, category_factory)
+    first_sku = create_sku(db_session, product, active_quantity=5, reserved_quantity=1)
+    second_sku = create_sku(
+        db_session,
+        product,
+        name="256GB Black",
+        active_quantity=3,
+        reserved_quantity=0,
+    )
+
+    response = client.post(
+        "/api/v1/reserve",
+        json={
+            "idempotency_key": "reserve-all-skus",
+            "items": [
+                {"sku_id": first_sku.id, "quantity": 2},
+                {"sku_id": second_sku.id, "quantity": 1},
+            ],
+        },
+        headers=service_headers(),
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "reserved": True,
+        "items": [
+            {"sku_id": first_sku.id, "reserved_quantity": 2, "remaining_stock": 3},
+            {"sku_id": second_sku.id, "reserved_quantity": 1, "remaining_stock": 2},
+        ],
+    }
+    assert_sku_quantities(db_session, first_sku.id, active_quantity=3, reserved_quantity=3)
+    assert_sku_quantities(db_session, second_sku.id, active_quantity=2, reserved_quantity=1)
+    assert reserve_operation_count(db_session) == 1
+
+
+def test_partial_insufficient_stock_returns_409_all_rollback(
+    client,
+    db_session: Session,
+    category_factory,
+):
+    product = create_product(db_session, category_factory)
+    enough_sku = create_sku(db_session, product, active_quantity=5, reserved_quantity=1)
+    low_sku = create_sku(db_session, product, name="256GB Black", active_quantity=1, reserved_quantity=0)
+
+    response = client.post(
+        "/api/v1/reserve",
+        json={
+            "idempotency_key": "partial-insufficient",
+            "items": [
+                {"sku_id": enough_sku.id, "quantity": 2},
+                {"sku_id": low_sku.id, "quantity": 2},
+            ],
+        },
+        headers=service_headers(),
+    )
+
+    assert response.status_code == 409
+    assert response.json() == {
+        "reserved": False,
+        "failed_items": [
+            {
+                "sku_id": low_sku.id,
+                "requested": 2,
+                "available": 1,
+                "reason": "INSUFFICIENT_STOCK",
+            }
+        ],
+    }
+    assert_sku_quantities(db_session, enough_sku.id, active_quantity=5, reserved_quantity=1)
+    assert_sku_quantities(db_session, low_sku.id, active_quantity=1, reserved_quantity=0)
+    assert reserve_operation_count(db_session) == 0
+
+
+def test_idempotent_reserve_returns_200_without_double_deduction(
+    client,
+    db_session: Session,
+    category_factory,
+):
+    product = create_product(db_session, category_factory)
+    sku = create_sku(db_session, product, active_quantity=5, reserved_quantity=0)
+    payload = reserve_payload("same-reserve-key", sku, 2)
+
+    first_response = client.post("/api/v1/reserve", json=payload, headers=service_headers())
+    second_response = client.post("/api/v1/reserve", json=payload, headers=service_headers())
+
+    assert first_response.status_code == 200
+    assert second_response.status_code == 200
+    assert second_response.json() == first_response.json()
+    assert_sku_quantities(db_session, sku.id, active_quantity=3, reserved_quantity=2)
+    assert reserve_operation_count(db_session) == 1
+
+
+def test_sku_out_of_stock_event_emitted(
+    client,
+    db_session: Session,
+    category_factory,
+    monkeypatch,
+):
+    requests = []
+
+    def fake_post(url, json, headers, timeout):
+        requests.append(
+            {
+                "url": url,
+                "json": json,
+                "headers": headers,
+                "timeout": timeout,
+            }
+        )
+        return FakeB2CResponse()
+
+    monkeypatch.setattr("src.services.b2c_service.httpx.post", fake_post)
+    product = create_product(db_session, category_factory)
+    sku = create_sku(db_session, product, active_quantity=2, reserved_quantity=0)
+
+    response = client.post(
+        "/api/v1/reserve",
+        json=reserve_payload("sku-out-of-stock", sku, 2),
+        headers=service_headers(),
+    )
+
+    assert response.status_code == 200
+    assert len(requests) == 1
+    request = requests[0]
+    assert request["url"] == f"{settings.b2c_url.rstrip('/')}/api/v1/events/product"
+    assert request["headers"]["X-Service-Key"] == settings.b2b_to_b2c_key
+    assert request["timeout"] == settings.b2c_timeout_seconds
+    assert request["json"]["idempotency_key"] == "sku-out-of-stock"
+    assert request["json"]["event"] == "SKU_OUT_OF_STOCK"
+    assert request["json"]["product_id"] == product.id
+    assert request["json"]["sku_id"] == sku.id
+    assert request["json"]["date"]
+
+
+def test_unreserve_restores_quantities(client, db_session: Session, category_factory):
+    product = create_product(db_session, category_factory)
+    sku = create_sku(db_session, product, active_quantity=3, reserved_quantity=5)
+
+    response = client.post(
+        "/api/v1/unreserve",
+        json=unreserve_payload("order-1", sku, 2),
+        headers=service_headers(),
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    assert_sku_quantities(db_session, sku.id, active_quantity=5, reserved_quantity=3)
+
+
+def test_hidden_deleted_and_missing_skus_return_out_of_stock(
+    client,
+    db_session: Session,
+    category_factory,
+):
+    hidden_product = create_product(db_session, category_factory, status=ProductStatus.CREATED)
+    deleted_product = create_product(db_session, category_factory, deleted=True)
+    hidden_sku = create_sku(db_session, hidden_product, active_quantity=7, reserved_quantity=0)
+    deleted_sku = create_sku(db_session, deleted_product, active_quantity=8, reserved_quantity=0)
+    missing_sku_id = 999999
+
+    response = client.post(
+        "/api/v1/reserve",
+        json={
+            "idempotency_key": "hidden-and-missing",
+            "items": [
+                {"sku_id": hidden_sku.id, "quantity": 1},
+                {"sku_id": deleted_sku.id, "quantity": 1},
+                {"sku_id": missing_sku_id, "quantity": 1},
+            ],
+        },
+        headers=service_headers(),
+    )
+
+    assert response.status_code == 409
+    assert response.json() == {
+        "reserved": False,
+        "failed_items": [
+            {
+                "sku_id": hidden_sku.id,
+                "requested": 1,
+                "available": 0,
+                "reason": "OUT_OF_STOCK",
+            },
+            {
+                "sku_id": deleted_sku.id,
+                "requested": 1,
+                "available": 0,
+                "reason": "OUT_OF_STOCK",
+            },
+            {
+                "sku_id": missing_sku_id,
+                "requested": 1,
+                "available": 0,
+                "reason": "OUT_OF_STOCK",
+            },
+        ],
+    }
+    assert_sku_quantities(db_session, hidden_sku.id, active_quantity=7, reserved_quantity=0)
+    assert_sku_quantities(db_session, deleted_sku.id, active_quantity=8, reserved_quantity=0)
+
+
+def test_same_idempotency_key_with_different_payload_returns_409(
+    client,
+    db_session: Session,
+    category_factory,
+):
+    product = create_product(db_session, category_factory)
+    sku = create_sku(db_session, product, active_quantity=5, reserved_quantity=0)
+
+    first_response = client.post(
+        "/api/v1/reserve",
+        json=reserve_payload("different-payload-key", sku, 1),
+        headers=service_headers(),
+    )
+    second_response = client.post(
+        "/api/v1/reserve",
+        json=reserve_payload("different-payload-key", sku, 2),
+        headers=service_headers(),
+    )
+
+    assert first_response.status_code == 200
+    assert second_response.status_code == 409
+    assert second_response.json() == {
+        "code": "CONFLICT",
+        "message": "idempotency_key was already used with a different payload",
+    }
+    assert_sku_quantities(db_session, sku.id, active_quantity=4, reserved_quantity=1)
+
+
+def test_reserve_rollback_does_not_emit_sku_out_of_stock(
+    client,
+    db_session: Session,
+    category_factory,
+    monkeypatch,
+):
+    requests = []
+
+    def fake_post(url, json, headers, timeout):
+        requests.append(json)
+        return FakeB2CResponse()
+
+    monkeypatch.setattr("src.services.b2c_service.httpx.post", fake_post)
+    product = create_product(db_session, category_factory)
+    enough_sku = create_sku(db_session, product, active_quantity=1, reserved_quantity=0)
+    low_sku = create_sku(db_session, product, name="256GB Black", active_quantity=1, reserved_quantity=0)
+
+    response = client.post(
+        "/api/v1/reserve",
+        json={
+            "idempotency_key": "rollback-no-event",
+            "items": [
+                {"sku_id": enough_sku.id, "quantity": 1},
+                {"sku_id": low_sku.id, "quantity": 2},
+            ],
+        },
+        headers=service_headers(),
+    )
+
+    assert response.status_code == 409
+    assert requests == []
+    assert_sku_quantities(db_session, enough_sku.id, active_quantity=1, reserved_quantity=0)
+    assert_sku_quantities(db_session, low_sku.id, active_quantity=1, reserved_quantity=0)
+
+
+def test_idempotent_replay_does_not_emit_duplicate_sku_out_of_stock(
+    client,
+    db_session: Session,
+    category_factory,
+    monkeypatch,
+):
+    requests = []
+
+    def fake_post(url, json, headers, timeout):
+        requests.append(json)
+        return FakeB2CResponse()
+
+    monkeypatch.setattr("src.services.b2c_service.httpx.post", fake_post)
+    product = create_product(db_session, category_factory)
+    sku = create_sku(db_session, product, active_quantity=1, reserved_quantity=0)
+    payload = reserve_payload("no-duplicate-event", sku, 1)
+
+    first_response = client.post("/api/v1/reserve", json=payload, headers=service_headers())
+    second_response = client.post("/api/v1/reserve", json=payload, headers=service_headers())
+
+    assert first_response.status_code == 200
+    assert second_response.status_code == 200
+    assert len(requests) == 1
+
+
+def test_unreserve_cannot_make_reserved_quantity_negative(
+    client,
+    db_session: Session,
+    category_factory,
+):
+    product = create_product(db_session, category_factory)
+    sku = create_sku(db_session, product, active_quantity=3, reserved_quantity=1)
+
+    response = client.post(
+        "/api/v1/unreserve",
+        json=unreserve_payload("order-negative-reserve", sku, 2),
+        headers=service_headers(),
+    )
+
+    assert response.status_code == 409
+    assert response.json() == {
+        "code": "CONFLICT",
+        "message": "Insufficient reserved quantity",
+    }
+    assert_sku_quantities(db_session, sku.id, active_quantity=3, reserved_quantity=1)
+
+
+def test_missing_or_invalid_service_key_returns_401(
+    client,
+    db_session: Session,
+    category_factory,
+    auth_headers,
+):
+    product = create_product(db_session, category_factory)
+    sku = create_sku(db_session, product, active_quantity=5, reserved_quantity=0)
+
+    missing_response = client.post(
+        "/api/v1/reserve",
+        json=reserve_payload("missing-service-key", sku, 1),
+        headers=auth_headers(SELLER_ID),
+    )
+    invalid_response = client.post(
+        "/api/v1/unreserve",
+        json=unreserve_payload("invalid-service-key", sku, 1),
+        headers={"X-Service-Key": "wrong-key"},
+    )
+
+    assert missing_response.status_code == 401
+    assert invalid_response.status_code == 401
+    assert missing_response.json() == {"code": "UNAUTHORIZED", "message": "Authorization required"}
+    assert invalid_response.json() == {"code": "UNAUTHORIZED", "message": "Authorization required"}
+    assert_sku_quantities(db_session, sku.id, active_quantity=5, reserved_quantity=0)


### PR DESCRIPTION
# US-B2B-08 Summary

Migrated US-B2B-08 reserve/unreserve to the canonical inventory routes from `flow/openapi.yaml`. This matches the previously reviewed `neomarket-b2b.yaml` inventory reserve/unreserve contract.

Added `POST /api/v1/inventory/reserve` and `POST /api/v1/inventory/unreserve`, both authenticated only by `X-Service-Key == settings.b2c_to_b2b_key`. Seller JWTs are not accepted as a substitute. Reserve validates `idempotency_key`, `order_id`, non-empty `items`, UUID-format `sku_id`, and `quantity > 0`; unreserve validates `order_id`, non-empty `items`, UUID-format `sku_id`, and `quantity > 0`.

Kept `POST /api/v1/reserve` and `POST /api/v1/unreserve` as legacy compatibility routes with their original response shapes.

Reserve is all-or-nothing against catalog-visible stock only: parent product must be `MODERATED`, not deleted, and have enough `active_quantity`. Hidden, deleted, nonexistent, and non-moderated SKUs return the non-leaking reserve conflict shape with `available: 0` and `OUT_OF_STOCK`; visible SKUs with positive but insufficient stock return `INSUFFICIENT_STOCK`. Successful reserve decrements `active_quantity`, increments `reserved_quantity`, stores a cached success response in `reserve_operations`, and emits `SKU_OUT_OF_STOCK` after commit when a SKU reaches zero active stock.

Canonical reserve returns `{"order_id","status":"RESERVED","reserved_at"}`. Canonical reserve idempotency includes `order_id` in the normalized request hash, so same `idempotency_key` + same `order_id` + same normalized items replays with the original `reserved_at`, while changing either `order_id` or items returns `409 CONFLICT`. Legacy reserve continues to hash without `order_id`.

Canonical reserve stock conflicts now return `409 {"code":"CONFLICT","message":"Unable to reserve inventory","details":{"failed_items":[...]}}`. The legacy reserve conflict shape remains `{"reserved":false,"failed_items":[...]}`.

Unreserve restores stock in one transaction by moving quantities from `reserved_quantity` back to `active_quantity`. Canonical unreserve returns `{"order_id","status":"UNRESERVED","processed_at"}`. If any item would make `reserved_quantity` negative, it returns `409 {"code":"CONFLICT","message":"Insufficient reserved quantity"}` and rolls back all changes. No persistent unreserve replay was added; unreserve idempotency remains unchanged from the existing US-B2B-08 behavior because the schema has no order-operation storage table.

No US-B2B-09+ behavior was implemented: no moderation event alias, no fulfill, no seller list migration, and no SKU delete behavior.

PostgreSQL production uses `SELECT FOR UPDATE` for SKU rows inside the reserve/unreserve transaction. SQLite tests verify deterministic all-or-nothing behavior but do not prove real row-lock semantics. B2C event delivery is best-effort after a successful reserve commit; delivery failure is logged and does not roll back stock changes.

# US-B2B-08 Validation

Pytest proof commands:

```powershell
python -m pytest tests/api/test_reservations.py -vv
python -m pytest tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py tests/api/test_reservations.py -vv
```

Required scenario results:

- `test_inventory_reserve_returns_openapi_response`: passed
- `test_inventory_reserve_requires_order_id`: passed
- `test_inventory_reserve_idempotent_replay_returns_same_reserved_at_without_double_deduction`: passed
- `test_inventory_reserve_same_key_different_order_id_returns_409`: passed
- `test_inventory_reserve_conflict_returns_error_with_failed_items_details_and_rolls_back`: passed
- `test_inventory_unreserve_returns_openapi_response`: passed
- `test_legacy_reserve_and_unreserve_routes_keep_response_shapes`: passed

Suite results:

- `tests/api/test_reservations.py`: 18 passed
- `tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py tests/api/test_reservations.py`: 75 passed

# ADR: Inventory OpenAPI Migration Strategy

Options considered:

- Add canonical inventory routes on the existing reservation service: selected. It aligns B2C calls with `flow/openapi.yaml` while preserving the tested reserve transaction and event semantics.
- Replace legacy reserve/unreserve routes: rejected because existing callers still depend on `/api/v1/reserve` and `/api/v1/unreserve` response shapes.
- Add persistent unreserve replay storage: rejected for this migration because it would require a new order-operation model beyond US-B2B-08 and is explicitly deferred.

Decision: add `POST /api/v1/inventory/reserve` and `POST /api/v1/inventory/unreserve` as canonical wrappers over the existing reservation service. Canonical reserve passes `order_id` into the normalized idempotency hash and derives `reserved_at` from `ReserveOperation.created_at`; legacy reserve omits `order_id` and keeps its cached response. Canonical unreserve returns the OpenAPI response shape but does not add persistent replay.

# ADR: Reservation UUID Request Boundary

After the UUID migration, reservation HTTP request bodies must carry `sku_id` as JSON strings because real clients cannot send Python `uuid.UUID` objects. The route parses those strings into `uuid.UUID` instances for service and SQLAlchemy lookups, while cached reservation payloads, API responses, failed items, and B2C event payloads serialize UUID identifiers back to strings at the JSON boundary.

Decision: keep reservation lookup and schema types UUID-aware, remove integer SKU parsing from reserve/unreserve normalization, and update reservation tests to send `str(sku.id)` in all JSON payloads. Reservation business logic, idempotency rules, all-or-nothing stock behavior, and legacy/canonical route behavior are unchanged.