### PR TITLE
US-B2B-10: Implement fulfillment

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -581,7 +581,6 @@ Options considered:
 - Replace `/api/v1/events/moderation`: rejected because the existing B2B flow and tests still cover that compatibility route and its `200` response body.
 - Convert moderation event boundaries to UUID strings after the UUID migration: selected. Real HTTP clients send UUIDs as strings, while the route/service keep internal lookups UUID-aware.
 
-<<<<<<< HEAD
 Decision: keep the moderation business behavior stable and perform OpenAPI migration at the route/schema boundary. The canonical route normalizes request fields into the existing service payload, returns bodyless `204` responses, and preserves existing idempotency conflict behavior.
 
 # ADR: Moderation UUID Request Boundary
@@ -589,8 +588,6 @@ Decision: keep the moderation business behavior stable and perform OpenAPI migra
 After the UUID migration, moderation HTTP request bodies must carry `product_id` as JSON strings because real clients cannot send Python `uuid.UUID` objects. Both moderation routes parse those strings into `uuid.UUID` instances for service and SQLAlchemy lookups, while processed-event JSON payloads, cached responses, legacy route responses, and B2C `PRODUCT_BLOCKED` events serialize product identifiers back to strings at the JSON boundary.
 
 Decision: keep moderation schemas and persistence UUID-aware, remove integer product ID parsing from moderation event routes, and update moderation tests to send `str(product.id)` in all JSON payloads. Moderation status transitions, idempotency behavior, service-key authentication, and B2C event behavior are unchanged.
-=======
-Decision: keep the service model stable and perform OpenAPI migration at the route/schema boundary. The canonical route normalizes request fields into the existing service payload, returns bodyless `204` responses, and preserves existing idempotency conflict behavior.
 
 ---
 
@@ -608,12 +605,12 @@ The request shape follows the canonical flow field names:
 {
   "order_id": "order-id",
   "items": [
-    {"sku_id": 1, "quantity": 2}
+    {"sku_id": "0fbd7d25-6f5b-4c3c-8c0e-78be4d56c1cc", "quantity": 2}
   ]
 }
 ```
 
-Route-local validation requires `order_id`, a non-empty `items` list, positive integer `sku_id`, and `quantity > 0`, returning canonical `400 INVALID_REQUEST` errors instead of FastAPI `422`. The OpenAPI examples show UUID-shaped IDs, but this service currently uses integer SKU primary keys consistently with reserve/unreserve, so fulfill keeps integer `sku_id`.
+Route-local validation requires `order_id`, a non-empty `items` list, UUID-format string `sku_id`, and `quantity > 0`, returning canonical `400 INVALID_REQUEST` errors instead of FastAPI `422`. The route parses JSON string SKU ids into internal `uuid.UUID` values for service and SQLAlchemy lookups.
 
 Fulfill finalizes an existing delivered order/reservation by decreasing `reserved_quantity` only:
 
@@ -640,6 +637,7 @@ No US-B2B-11+ behavior is included: no seller list migration and no SKU delete b
 Pytest proof command:
 
 ```powershell
+python -m pytest tests/api/test_fulfillment.py -vv
 python -m pytest tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py tests/api/test_reservations.py tests/api/test_moderation_events.py tests/api/test_fulfillment.py -vv
 ```
 
@@ -665,7 +663,7 @@ Suite results:
 
 - `tests/api/test_fulfillment.py`: 12 passed
 - Required US-B2B-10 OpenAPI migration scenarios: 4 passed
-- `tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py tests/api/test_reservations.py tests/api/test_moderation_events.py tests/api/test_fulfillment.py`: 99 passed
+- `tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py tests/api/test_reservations.py tests/api/test_moderation_events.py tests/api/test_fulfillment.py`: 103 passed
 
 # ADR: Fulfill Idempotency by Order ID
 
@@ -676,4 +674,9 @@ Options considered:
 - Checking `reserved_quantity` only: lowest implementation complexity, but not true idempotency. It cannot distinguish a legitimate retry from a conflicting request and can produce false success or double-deduction risk under concurrent/retried calls.
 
 Decision: use a persisted `fulfilled_orders` table. The service claims `order_id`, locks all requested SKUs with `SELECT FOR UPDATE` where supported, validates all items, deducts `reserved_quantity`, stores the cached success response, and commits in one transaction. Validation and stock conflicts roll back the idempotency row and stock changes, so failed fulfill attempts are not replay-cached.
->>>>>>> 3a98afa (Implement US-B2B-10 fulfillment)
+
+# ADR: Fulfillment UUID Request Boundary
+
+After the UUID migration, fulfillment HTTP request bodies must carry `sku_id` as JSON strings because real clients cannot send Python `uuid.UUID` objects. Both canonical `/api/v1/inventory/fulfill` and legacy `/api/v1/fulfill` parse those strings into `uuid.UUID` instances for service and SQLAlchemy lookups, while persisted idempotency payloads serialize SKU identifiers back to strings.
+
+Decision: keep fulfillment schemas, routing, and service logic UUID-aware, remove integer SKU parsing from fulfill normalization, and update fulfillment tests to send `str(sku.id)` in all JSON payloads. Fulfillment idempotency, service-key authentication, reserved stock deduction, active stock behavior, and all-or-nothing rollback behavior are unchanged.

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -581,6 +581,7 @@ Options considered:
 - Replace `/api/v1/events/moderation`: rejected because the existing B2B flow and tests still cover that compatibility route and its `200` response body.
 - Convert moderation event boundaries to UUID strings after the UUID migration: selected. Real HTTP clients send UUIDs as strings, while the route/service keep internal lookups UUID-aware.
 
+<<<<<<< HEAD
 Decision: keep the moderation business behavior stable and perform OpenAPI migration at the route/schema boundary. The canonical route normalizes request fields into the existing service payload, returns bodyless `204` responses, and preserves existing idempotency conflict behavior.
 
 # ADR: Moderation UUID Request Boundary
@@ -588,3 +589,86 @@ Decision: keep the moderation business behavior stable and perform OpenAPI migra
 After the UUID migration, moderation HTTP request bodies must carry `product_id` as JSON strings because real clients cannot send Python `uuid.UUID` objects. Both moderation routes parse those strings into `uuid.UUID` instances for service and SQLAlchemy lookups, while processed-event JSON payloads, cached responses, legacy route responses, and B2C `PRODUCT_BLOCKED` events serialize product identifiers back to strings at the JSON boundary.
 
 Decision: keep moderation schemas and persistence UUID-aware, remove integer product ID parsing from moderation event routes, and update moderation tests to send `str(product.id)` in all JSON payloads. Moderation status transitions, idempotency behavior, service-key authentication, and B2C event behavior are unchanged.
+=======
+Decision: keep the service model stable and perform OpenAPI migration at the route/schema boundary. The canonical route normalizes request fields into the existing service payload, returns bodyless `204` responses, and preserves existing idempotency conflict behavior.
+
+---
+
+# US-B2B-10 Summary
+
+Implemented `POST /api/v1/fulfill` on top of the stacked US-B2B-01 through US-B2B-09 changes. This slice depends on US-B2B-01 through US-B2B-09 until those changes are merged.
+
+Fulfill is a B2C service-to-service endpoint and authenticates only with `X-Service-Key == settings.b2c_to_b2b_key`, matching `flow/b2b-flows.md#fulfill-delivery`. Seller JWTs are not required and are not accepted as a substitute. Missing or invalid service keys return `401 {"code":"UNAUTHORIZED","message":"Authorization required"}`.
+
+The request shape follows the canonical flow field names:
+
+```json
+{
+  "order_id": "order-id",
+  "items": [
+    {"sku_id": 1, "quantity": 2}
+  ]
+}
+```
+
+Route-local validation requires `order_id`, a non-empty `items` list, positive integer `sku_id`, and `quantity > 0`, returning canonical `400 INVALID_REQUEST` errors instead of FastAPI `422`. The flow examples show UUID-shaped IDs, but this service currently uses integer SKU primary keys consistently with reserve/unreserve, so fulfill keeps integer `sku_id`.
+
+Fulfill finalizes an existing delivered order/reservation by decreasing `reserved_quantity` only:
+
+- `reserved_quantity -= quantity`
+- `active_quantity` remains unchanged
+- `active_quantity + reserved_quantity` intentionally decreases because delivered goods have physically left stock
+- no stock restore
+- no order creation/cancellation
+- no product moderation state changes
+- no stock acceptance or invoice events
+- no invoice `accepted_quantity` mutation
+
+Fulfill validates SKU existence and sufficient `reserved_quantity`; it does not require current catalog visibility. This follows the lifecycle assumption that fulfill acts on an already-created order/reservation and must still be able to complete if product visibility changed after checkout.
+
+Added `fulfilled_orders`, keyed by `order_id`, with `request_hash`, normalized `request_payload`, cached success `response`, and `created_at`. The fulfilled order record is written in the same DB transaction as the reserved stock deductions. Replaying the same `order_id` with the same normalized payload returns cached `200 {"ok": true}` without double deduction. Reusing the same `order_id` with a different payload returns `409 CONFLICT`; the flow only defines same-order retry behavior, so this conflict behavior is an explicit implementation assumption.
+
+Fulfill is atomic across all requested items. The service claims the `order_id`, locks requested SKUs with `SELECT FOR UPDATE` where supported, validates every item, deducts all reserved quantities, stores the success response, and commits. If any item is missing or has insufficient reserved quantity, the transaction rolls back, no fulfilled-order success record is written, and no SKU is partially fulfilled. SQLite tests do not enforce row locks, but PostgreSQL uses the generated `SELECT FOR UPDATE`; deterministic tests cover rollback/all-or-nothing behavior.
+
+OpenAPI gap: `flow/b2b.yaml` lacks `POST /api/v1/fulfill` and has no equivalent fulfill/delivery operation or service-key security scheme, so no OpenAPI edit was made in this repository. The implementation follows `flow/b2b-flows.md#fulfill-delivery` and leaves `flow/*` unchanged.
+
+# US-B2B-10 Validation
+
+Pytest proof commands:
+
+```powershell
+python -m pytest tests/api/test_fulfillment.py -vv
+python -m pytest tests/api/test_fulfillment.py -k "fulfill_decreases_reserved_quantity or active_quantity_unchanged or idempotent_fulfill_no_double_deduction or missing_service_key_returns_401" -vv
+python -m pytest tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py tests/api/test_reservations.py tests/api/test_moderation_events.py tests/api/test_fulfillment.py -vv
+```
+
+Required scenario results:
+
+- `test_fulfill_decreases_reserved_quantity`: passed
+- `test_active_quantity_unchanged`: passed
+- `test_idempotent_fulfill_no_double_deduction`: passed
+- `test_missing_service_key_returns_401`: passed
+
+Additional safety results:
+
+- `test_same_order_id_with_different_payload_returns_409`: passed
+- `test_insufficient_reserved_quantity_rolls_back_all_items`: passed
+- `test_invalid_quantity_returns_400`: passed
+- `test_seller_jwt_without_service_key_returns_401`: passed
+
+Suite results:
+
+- `tests/api/test_fulfillment.py`: 8 passed
+- Required US-B2B-10 scenarios: 4 passed, 4 deselected
+- `tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py tests/api/test_reservations.py tests/api/test_moderation_events.py tests/api/test_fulfillment.py`: 65 passed
+
+# ADR: Fulfill Idempotency by Order ID
+
+Options considered:
+
+- DB-backed `fulfilled_orders` table keyed by `order_id`: selected. It has moderate implementation complexity, but gives the lowest double-deduction risk on retries because the request hash, normalized payload, cached response, and successful fulfillment are persisted across process restarts.
+- `last_fulfilled_order` field on SKU: lower implementation complexity, but unsafe for multi-SKU orders and payload conflict detection. It cannot represent order-level idempotency cleanly and risks inconsistent retry behavior.
+- Checking `reserved_quantity` only: lowest implementation complexity, but not true idempotency. It cannot distinguish a legitimate retry from a conflicting request and can produce false success or double-deduction risk under concurrent/retried calls.
+
+Decision: use a persisted `fulfilled_orders` table. The service claims `order_id`, locks all requested SKUs with `SELECT FOR UPDATE` where supported, validates all items, deducts `reserved_quantity`, stores the cached success response, and commits in one transaction. Validation and stock conflicts roll back the idempotency row and stock changes, so failed fulfill attempts are not replay-cached.
+>>>>>>> 3a98afa (Implement US-B2B-10 fulfillment)

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -596,9 +596,11 @@ Decision: keep the service model stable and perform OpenAPI migration at the rou
 
 # US-B2B-10 Summary
 
-Implemented `POST /api/v1/fulfill` on top of the stacked US-B2B-01 through US-B2B-09 changes. This slice depends on US-B2B-01 through US-B2B-09 until those changes are merged.
+US-B2B-10 is migrated to the final authoritative `flow/openapi.yaml` inventory fulfill contract. For the affected fulfill endpoint, this contract matches the previously reviewed `neomarket-b2b.yaml` inventory fulfill contract.
 
-Fulfill is a B2C service-to-service endpoint and authenticates only with `X-Service-Key == settings.b2c_to_b2b_key`, matching `flow/b2b-flows.md#fulfill-delivery`. Seller JWTs are not required and are not accepted as a substitute. Missing or invalid service keys return `401 {"code":"UNAUTHORIZED","message":"Authorization required"}`.
+Added canonical `POST /api/v1/inventory/fulfill` while keeping legacy `POST /api/v1/fulfill` on top of the stacked US-B2B-01 through US-B2B-09 changes. This slice depends on US-B2B-01 through US-B2B-09 until those changes are merged.
+
+Fulfill is a B2C service-to-service endpoint and authenticates only with `X-Service-Key == settings.b2c_to_b2b_key`, matching `flow/openapi.yaml`. Seller JWTs are not required and are not accepted as a substitute. Missing or invalid service keys return `401 {"code":"UNAUTHORIZED","message":"Authorization required"}`.
 
 The request shape follows the canonical flow field names:
 
@@ -611,13 +613,14 @@ The request shape follows the canonical flow field names:
 }
 ```
 
-Route-local validation requires `order_id`, a non-empty `items` list, positive integer `sku_id`, and `quantity > 0`, returning canonical `400 INVALID_REQUEST` errors instead of FastAPI `422`. The flow examples show UUID-shaped IDs, but this service currently uses integer SKU primary keys consistently with reserve/unreserve, so fulfill keeps integer `sku_id`.
+Route-local validation requires `order_id`, a non-empty `items` list, positive integer `sku_id`, and `quantity > 0`, returning canonical `400 INVALID_REQUEST` errors instead of FastAPI `422`. The OpenAPI examples show UUID-shaped IDs, but this service currently uses integer SKU primary keys consistently with reserve/unreserve, so fulfill keeps integer `sku_id`.
 
 Fulfill finalizes an existing delivered order/reservation by decreasing `reserved_quantity` only:
 
 - `reserved_quantity -= quantity`
 - `active_quantity` remains unchanged
 - `active_quantity + reserved_quantity` intentionally decreases because delivered goods have physically left stock
+- `flow/openapi.yaml` mentions `stock_quantity`; this codebase maps buyer-visible stock through `active_quantity`, and fulfill finalizes reserved stock by decreasing `reserved_quantity` only
 - no stock restore
 - no order creation/cancellation
 - no product moderation state changes
@@ -626,31 +629,33 @@ Fulfill finalizes an existing delivered order/reservation by decreasing `reserve
 
 Fulfill validates SKU existence and sufficient `reserved_quantity`; it does not require current catalog visibility. This follows the lifecycle assumption that fulfill acts on an already-created order/reservation and must still be able to complete if product visibility changed after checkout.
 
-Added `fulfilled_orders`, keyed by `order_id`, with `request_hash`, normalized `request_payload`, cached success `response`, and `created_at`. The fulfilled order record is written in the same DB transaction as the reserved stock deductions. Replaying the same `order_id` with the same normalized payload returns cached `200 {"ok": true}` without double deduction. Reusing the same `order_id` with a different payload returns `409 CONFLICT`; the flow only defines same-order retry behavior, so this conflict behavior is an explicit implementation assumption.
+Added `fulfilled_orders`, keyed by `order_id`, with `request_hash`, normalized `request_payload`, cached legacy success `response`, and `created_at`. The fulfilled order record is written in the same DB transaction as the reserved stock deductions. Replaying the same `order_id` with the same normalized payload returns without double deduction. The canonical route returns `200 {"order_id":"...","status":"FULFILLED","processed_at":"..."}` with `processed_at` derived from persisted `fulfilled_orders.created_at`, so replay returns the same timestamp. The legacy route keeps returning cached `200 {"ok": true}`. Reusing the same `order_id` with a different payload returns `409 CONFLICT`; the flow only defines same-order retry behavior, so this conflict behavior is an explicit implementation assumption.
 
 Fulfill is atomic across all requested items. The service claims the `order_id`, locks requested SKUs with `SELECT FOR UPDATE` where supported, validates every item, deducts all reserved quantities, stores the success response, and commits. If any item is missing or has insufficient reserved quantity, the transaction rolls back, no fulfilled-order success record is written, and no SKU is partially fulfilled. SQLite tests do not enforce row locks, but PostgreSQL uses the generated `SELECT FOR UPDATE`; deterministic tests cover rollback/all-or-nothing behavior.
 
-OpenAPI gap: `flow/b2b.yaml` lacks `POST /api/v1/fulfill` and has no equivalent fulfill/delivery operation or service-key security scheme, so no OpenAPI edit was made in this repository. The implementation follows `flow/b2b-flows.md#fulfill-delivery` and leaves `flow/*` unchanged.
+No US-B2B-11+ behavior is included: no seller list migration and no SKU delete behavior.
 
 # US-B2B-10 Validation
 
-Pytest proof commands:
+Pytest proof command:
 
 ```powershell
-python -m pytest tests/api/test_fulfillment.py -vv
-python -m pytest tests/api/test_fulfillment.py -k "fulfill_decreases_reserved_quantity or active_quantity_unchanged or idempotent_fulfill_no_double_deduction or missing_service_key_returns_401" -vv
 python -m pytest tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py tests/api/test_reservations.py tests/api/test_moderation_events.py tests/api/test_fulfillment.py -vv
 ```
 
 Required scenario results:
 
+- `test_inventory_fulfill_returns_openapi_response`: passed
+- `test_inventory_fulfill_idempotent_replay_returns_same_response_without_double_deduction`: passed
+- `test_inventory_fulfill_missing_service_key_returns_401`: passed
+- `test_legacy_fulfill_route_still_returns_ok`: passed
+
+Additional safety results:
+
 - `test_fulfill_decreases_reserved_quantity`: passed
 - `test_active_quantity_unchanged`: passed
 - `test_idempotent_fulfill_no_double_deduction`: passed
 - `test_missing_service_key_returns_401`: passed
-
-Additional safety results:
-
 - `test_same_order_id_with_different_payload_returns_409`: passed
 - `test_insufficient_reserved_quantity_rolls_back_all_items`: passed
 - `test_invalid_quantity_returns_400`: passed
@@ -658,9 +663,9 @@ Additional safety results:
 
 Suite results:
 
-- `tests/api/test_fulfillment.py`: 8 passed
-- Required US-B2B-10 scenarios: 4 passed, 4 deselected
-- `tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py tests/api/test_reservations.py tests/api/test_moderation_events.py tests/api/test_fulfillment.py`: 65 passed
+- `tests/api/test_fulfillment.py`: 12 passed
+- Required US-B2B-10 OpenAPI migration scenarios: 4 passed
+- `tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py tests/api/test_reservations.py tests/api/test_moderation_events.py tests/api/test_fulfillment.py`: 99 passed
 
 # ADR: Fulfill Idempotency by Order ID
 

--- a/migrations/versions/0010_add_fulfilled_orders.py
+++ b/migrations/versions/0010_add_fulfilled_orders.py
@@ -1,0 +1,28 @@
+"""Add fulfilled orders."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0010_add_fulfilled_orders"
+down_revision = "0009_add_processed_moderation_events"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "fulfilled_orders",
+        sa.Column("order_id", sa.String(length=255), nullable=False),
+        sa.Column("request_hash", sa.String(length=64), nullable=False),
+        sa.Column("request_payload", sa.JSON(), nullable=False),
+        sa.Column("response", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint("order_id", name=op.f("pk_fulfilled_orders")),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("fulfilled_orders")

--- a/src/api/router.py
+++ b/src/api/router.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter
 
 from src.api.routes import (
+    fulfillment,
     invoices,
     moderation_events,
     products,
@@ -16,4 +17,5 @@ api_router.include_router(skus.router)
 api_router.include_router(invoices.router)
 api_router.include_router(reservations.router)
 api_router.include_router(moderation_events.router)
+api_router.include_router(fulfillment.router)
 

--- a/src/api/routes/fulfillment.py
+++ b/src/api/routes/fulfillment.py
@@ -1,3 +1,4 @@
+import uuid
 from typing import Any
 
 from fastapi import APIRouter, Depends, Header, Request, status
@@ -42,26 +43,30 @@ async def _json_body(request: Request) -> dict[str, Any] | JSONResponse:
     return body
 
 
-def _parse_item(raw_item: Any) -> dict[str, int] | JSONResponse:
+def _parse_item(raw_item: Any) -> dict[str, Any] | JSONResponse:
     if not isinstance(raw_item, dict):
         return _invalid_request("Invalid fulfillment item")
 
-    sku_id = raw_item.get("sku_id")
+    raw_sku_id = raw_item.get("sku_id")
     quantity = raw_item.get("quantity")
-    if not isinstance(sku_id, int) or isinstance(sku_id, bool) or sku_id <= 0:
-        return _invalid_request("sku_id must be a positive integer")
+    if not isinstance(raw_sku_id, str):
+        return _invalid_request("sku_id must be a valid UUID")
+    try:
+        sku_id = uuid.UUID(raw_sku_id)
+    except ValueError:
+        return _invalid_request("sku_id must be a valid UUID")
     if not isinstance(quantity, int) or isinstance(quantity, bool) or quantity <= 0:
         return _invalid_request("quantity must be > 0")
 
     return {"sku_id": sku_id, "quantity": quantity}
 
 
-def _parse_items(body: dict[str, Any]) -> list[dict[str, int]] | JSONResponse:
+def _parse_items(body: dict[str, Any]) -> list[dict[str, Any]] | JSONResponse:
     raw_items = body.get("items")
     if not isinstance(raw_items, list) or not raw_items:
         return _invalid_request("At least one item is required")
 
-    items: list[dict[str, int]] = []
+    items: list[dict[str, Any]] = []
     for raw_item in raw_items:
         item = _parse_item(raw_item)
         if isinstance(item, JSONResponse):
@@ -70,7 +75,7 @@ def _parse_items(body: dict[str, Any]) -> list[dict[str, int]] | JSONResponse:
     return items
 
 
-async def _parse_fulfillment_payload(request: Request) -> tuple[str, list[dict[str, int]]] | JSONResponse:
+async def _parse_fulfillment_payload(request: Request) -> tuple[str, list[dict[str, Any]]] | JSONResponse:
     body = await _json_body(request)
     if isinstance(body, JSONResponse):
         return body

--- a/src/api/routes/fulfillment.py
+++ b/src/api/routes/fulfillment.py
@@ -1,0 +1,108 @@
+from typing import Any
+
+from fastapi import APIRouter, Depends, Header, Request, status
+from fastapi.responses import JSONResponse
+from sqlalchemy.orm import Session
+
+from src.api.deps import unauthorized_response
+from src.core.config import settings
+from src.db.session import get_db
+from src.schemas.fulfillment import FulfillmentRead
+from src.services.fulfillment_service import (
+    FulfillmentConflictError,
+    FulfillmentIdempotencyConflictError,
+    fulfill_skus,
+)
+
+router = APIRouter(tags=["Fulfillment"])
+
+
+def _error(status_code: int, code: str, message: str) -> JSONResponse:
+    return JSONResponse(status_code=status_code, content={"code": code, "message": message})
+
+
+def _invalid_request(message: str) -> JSONResponse:
+    return _error(400, "INVALID_REQUEST", message)
+
+
+def _validate_service_key(service_key: str | None) -> JSONResponse | None:
+    if service_key != settings.b2c_to_b2b_key:
+        return unauthorized_response()
+    return None
+
+
+async def _json_body(request: Request) -> dict[str, Any] | JSONResponse:
+    try:
+        body = await request.json()
+    except ValueError:
+        return _invalid_request("Invalid JSON body")
+
+    if not isinstance(body, dict):
+        return _invalid_request("Invalid fulfillment payload")
+    return body
+
+
+def _parse_item(raw_item: Any) -> dict[str, int] | JSONResponse:
+    if not isinstance(raw_item, dict):
+        return _invalid_request("Invalid fulfillment item")
+
+    sku_id = raw_item.get("sku_id")
+    quantity = raw_item.get("quantity")
+    if not isinstance(sku_id, int) or isinstance(sku_id, bool) or sku_id <= 0:
+        return _invalid_request("sku_id must be a positive integer")
+    if not isinstance(quantity, int) or isinstance(quantity, bool) or quantity <= 0:
+        return _invalid_request("quantity must be > 0")
+
+    return {"sku_id": sku_id, "quantity": quantity}
+
+
+def _parse_items(body: dict[str, Any]) -> list[dict[str, int]] | JSONResponse:
+    raw_items = body.get("items")
+    if not isinstance(raw_items, list) or not raw_items:
+        return _invalid_request("At least one item is required")
+
+    items: list[dict[str, int]] = []
+    for raw_item in raw_items:
+        item = _parse_item(raw_item)
+        if isinstance(item, JSONResponse):
+            return item
+        items.append(item)
+    return items
+
+
+async def _parse_fulfillment_payload(request: Request) -> tuple[str, list[dict[str, int]]] | JSONResponse:
+    body = await _json_body(request)
+    if isinstance(body, JSONResponse):
+        return body
+
+    order_id = body.get("order_id")
+    if not isinstance(order_id, str) or not order_id.strip():
+        return _invalid_request("order_id is required")
+
+    items = _parse_items(body)
+    if isinstance(items, JSONResponse):
+        return items
+    return order_id.strip(), items
+
+
+@router.post("/api/v1/fulfill", response_model=FulfillmentRead, status_code=status.HTTP_200_OK)
+async def fulfill_endpoint(
+    request: Request,
+    service_key: str | None = Header(default=None, alias="X-Service-Key"),
+    db: Session = Depends(get_db),
+) -> FulfillmentRead | JSONResponse:
+    auth_error = _validate_service_key(service_key)
+    if auth_error is not None:
+        return auth_error
+
+    payload = await _parse_fulfillment_payload(request)
+    if isinstance(payload, JSONResponse):
+        return payload
+    order_id, items = payload
+
+    try:
+        return fulfill_skus(db, order_id, items)
+    except FulfillmentConflictError:
+        return _error(409, "CONFLICT", "Insufficient reserved quantity")
+    except FulfillmentIdempotencyConflictError as exc:
+        return _error(409, "CONFLICT", str(exc))

--- a/src/api/routes/fulfillment.py
+++ b/src/api/routes/fulfillment.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 from src.api.deps import unauthorized_response
 from src.core.config import settings
 from src.db.session import get_db
-from src.schemas.fulfillment import FulfillmentRead
+from src.schemas.fulfillment import FulfillmentRead, InventoryFulfillmentRead
 from src.services.fulfillment_service import (
     FulfillmentConflictError,
     FulfillmentIdempotencyConflictError,
@@ -102,6 +102,33 @@ async def fulfill_endpoint(
 
     try:
         return fulfill_skus(db, order_id, items)
+    except FulfillmentConflictError:
+        return _error(409, "CONFLICT", "Insufficient reserved quantity")
+    except FulfillmentIdempotencyConflictError as exc:
+        return _error(409, "CONFLICT", str(exc))
+
+
+@router.post(
+    "/api/v1/inventory/fulfill",
+    response_model=InventoryFulfillmentRead,
+    status_code=status.HTTP_200_OK,
+)
+async def inventory_fulfill_endpoint(
+    request: Request,
+    service_key: str | None = Header(default=None, alias="X-Service-Key"),
+    db: Session = Depends(get_db),
+) -> InventoryFulfillmentRead | JSONResponse:
+    auth_error = _validate_service_key(service_key)
+    if auth_error is not None:
+        return auth_error
+
+    payload = await _parse_fulfillment_payload(request)
+    if isinstance(payload, JSONResponse):
+        return payload
+    order_id, items = payload
+
+    try:
+        return fulfill_skus(db, order_id, items, canonical=True)
     except FulfillmentConflictError:
         return _error(409, "CONFLICT", "Insufficient reserved quantity")
     except FulfillmentIdempotencyConflictError as exc:

--- a/src/db/base.py
+++ b/src/db/base.py
@@ -1,6 +1,7 @@
 from src.models import (
     Base,
     Category,
+    FulfilledOrder,
     Invoice,
     InvoiceItem,
     Product,
@@ -15,6 +16,7 @@ from src.models import (
 __all__ = [
     "Base",
     "Category",
+    "FulfilledOrder",
     "Product",
     "ProductImage",
     "ProductCharacteristic",

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,5 +1,6 @@
 from src.models.base import Base
 from src.models.category import Category
+from src.models.fulfillment import FulfilledOrder
 from src.models.invoice import Invoice, InvoiceItem, InvoiceStatus
 from src.models.product import Product, ProductCharacteristic, ProductImage, ProductStatus
 from src.models.processed_moderation_event import ProcessedModerationEvent
@@ -9,6 +10,7 @@ from src.models.sku import SKU, SKUCharacteristic
 __all__ = [
     "Base",
     "Category",
+    "FulfilledOrder",
     "Product",
     "ProductImage",
     "ProductCharacteristic",

--- a/src/models/fulfillment.py
+++ b/src/models/fulfillment.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import DateTime, JSON, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.models.base import Base
+
+
+class FulfilledOrder(Base):
+    __tablename__ = "fulfilled_orders"
+
+    order_id: Mapped[str] = mapped_column(String(255), primary_key=True)
+    request_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    request_payload: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+    response: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )

--- a/src/schemas/fulfillment.py
+++ b/src/schemas/fulfillment.py
@@ -1,5 +1,13 @@
+from datetime import datetime
+
 from src.schemas.common import APIModel
 
 
 class FulfillmentRead(APIModel):
     ok: bool
+
+
+class InventoryFulfillmentRead(APIModel):
+    order_id: str
+    status: str
+    processed_at: datetime

--- a/src/schemas/fulfillment.py
+++ b/src/schemas/fulfillment.py
@@ -1,0 +1,5 @@
+from src.schemas.common import APIModel
+
+
+class FulfillmentRead(APIModel):
+    ok: bool

--- a/src/services/fulfillment_service.py
+++ b/src/services/fulfillment_service.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import uuid
 from datetime import datetime, timezone
 from typing import Any
 
@@ -18,22 +19,25 @@ class FulfillmentIdempotencyConflictError(Exception):
     pass
 
 
-def _normalized_items(items: list[dict[str, int]]) -> list[dict[str, int]]:
-    quantities_by_sku: dict[int, int] = {}
+def _normalized_items(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    quantities_by_sku: dict[uuid.UUID, int] = {}
     for item in items:
-        sku_id = int(item["sku_id"])
+        sku_id = item["sku_id"]
         quantities_by_sku[sku_id] = quantities_by_sku.get(sku_id, 0) + int(item["quantity"])
 
     return [
         {"sku_id": sku_id, "quantity": quantity}
-        for sku_id, quantity in sorted(quantities_by_sku.items())
+        for sku_id, quantity in sorted(quantities_by_sku.items(), key=lambda value: str(value[0]))
     ]
 
 
-def _normalized_payload(order_id: str, items: list[dict[str, int]]) -> dict[str, Any]:
+def _normalized_payload(order_id: str, normalized_items: list[dict[str, Any]]) -> dict[str, Any]:
     return {
         "order_id": order_id,
-        "items": _normalized_items(items),
+        "items": [
+            {"sku_id": str(item["sku_id"]), "quantity": item["quantity"]}
+            for item in normalized_items
+        ],
     }
 
 
@@ -71,7 +75,7 @@ def _cached_response_or_conflict(
     return operation.response
 
 
-def _lock_skus(db: Session, sku_ids: list[int]) -> dict[int, SKU]:
+def _lock_skus(db: Session, sku_ids: list[uuid.UUID]) -> dict[uuid.UUID, SKU]:
     skus = db.scalars(select(SKU).where(SKU.id.in_(sku_ids)).with_for_update()).all()
     return {sku.id: sku for sku in skus}
 
@@ -79,12 +83,12 @@ def _lock_skus(db: Session, sku_ids: list[int]) -> dict[int, SKU]:
 def fulfill_skus(
     db: Session,
     order_id: str,
-    items: list[dict[str, int]],
+    items: list[dict[str, Any]],
     *,
     canonical: bool = False,
 ) -> dict[str, Any]:
-    normalized_payload = _normalized_payload(order_id, items)
-    normalized_items = normalized_payload["items"]
+    normalized_items = _normalized_items(items)
+    normalized_payload = _normalized_payload(order_id, normalized_items)
     request_hash = _request_hash(normalized_payload)
 
     existing_operation = db.get(FulfilledOrder, order_id)

--- a/src/services/fulfillment_service.py
+++ b/src/services/fulfillment_service.py
@@ -1,0 +1,98 @@
+import hashlib
+import json
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from src.models import FulfilledOrder, SKU
+
+
+class FulfillmentConflictError(Exception):
+    pass
+
+
+class FulfillmentIdempotencyConflictError(Exception):
+    pass
+
+
+def _normalized_items(items: list[dict[str, int]]) -> list[dict[str, int]]:
+    quantities_by_sku: dict[int, int] = {}
+    for item in items:
+        sku_id = int(item["sku_id"])
+        quantities_by_sku[sku_id] = quantities_by_sku.get(sku_id, 0) + int(item["quantity"])
+
+    return [
+        {"sku_id": sku_id, "quantity": quantity}
+        for sku_id, quantity in sorted(quantities_by_sku.items())
+    ]
+
+
+def _normalized_payload(order_id: str, items: list[dict[str, int]]) -> dict[str, Any]:
+    return {
+        "order_id": order_id,
+        "items": _normalized_items(items),
+    }
+
+
+def _request_hash(payload: dict[str, Any]) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _cached_response_or_conflict(operation: FulfilledOrder, request_hash: str) -> dict[str, Any]:
+    if operation.request_hash != request_hash:
+        raise FulfillmentIdempotencyConflictError(
+            "order_id was already used with a different payload"
+        )
+    return operation.response
+
+
+def _lock_skus(db: Session, sku_ids: list[int]) -> dict[int, SKU]:
+    skus = db.scalars(select(SKU).where(SKU.id.in_(sku_ids)).with_for_update()).all()
+    return {sku.id: sku for sku in skus}
+
+
+def fulfill_skus(db: Session, order_id: str, items: list[dict[str, int]]) -> dict[str, bool]:
+    normalized_payload = _normalized_payload(order_id, items)
+    normalized_items = normalized_payload["items"]
+    request_hash = _request_hash(normalized_payload)
+
+    existing_operation = db.get(FulfilledOrder, order_id)
+    if existing_operation is not None:
+        return _cached_response_or_conflict(existing_operation, request_hash)
+
+    response = {"ok": True}
+    operation = FulfilledOrder(
+        order_id=order_id,
+        request_hash=request_hash,
+        request_payload=normalized_payload,
+        response=response,
+    )
+    db.add(operation)
+
+    try:
+        db.flush()
+    except IntegrityError:
+        db.rollback()
+        existing_operation = db.get(FulfilledOrder, order_id)
+        if existing_operation is None:
+            raise FulfillmentIdempotencyConflictError("order_id is currently being processed")
+        return _cached_response_or_conflict(existing_operation, request_hash)
+
+    sku_ids = [item["sku_id"] for item in normalized_items]
+    sku_map = _lock_skus(db, sku_ids)
+
+    for item in normalized_items:
+        sku = sku_map.get(item["sku_id"])
+        if sku is None or sku.reserved_quantity < item["quantity"]:
+            db.rollback()
+            raise FulfillmentConflictError("Insufficient reserved quantity")
+
+    for item in normalized_items:
+        sku = sku_map[item["sku_id"]]
+        sku.reserved_quantity -= item["quantity"]
+
+    db.commit()
+    return response

--- a/src/services/fulfillment_service.py
+++ b/src/services/fulfillment_service.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+from datetime import datetime, timezone
 from typing import Any
 
 from sqlalchemy import select
@@ -41,11 +42,32 @@ def _request_hash(payload: dict[str, Any]) -> str:
     return hashlib.sha256(raw.encode("utf-8")).hexdigest()
 
 
-def _cached_response_or_conflict(operation: FulfilledOrder, request_hash: str) -> dict[str, Any]:
+def _timestamp(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.isoformat()
+
+
+def _canonical_fulfillment_response(operation: FulfilledOrder) -> dict[str, Any]:
+    return {
+        "order_id": operation.order_id,
+        "status": "FULFILLED",
+        "processed_at": _timestamp(operation.created_at),
+    }
+
+
+def _cached_response_or_conflict(
+    operation: FulfilledOrder,
+    request_hash: str,
+    *,
+    canonical: bool = False,
+) -> dict[str, Any]:
     if operation.request_hash != request_hash:
         raise FulfillmentIdempotencyConflictError(
             "order_id was already used with a different payload"
         )
+    if canonical:
+        return _canonical_fulfillment_response(operation)
     return operation.response
 
 
@@ -54,14 +76,20 @@ def _lock_skus(db: Session, sku_ids: list[int]) -> dict[int, SKU]:
     return {sku.id: sku for sku in skus}
 
 
-def fulfill_skus(db: Session, order_id: str, items: list[dict[str, int]]) -> dict[str, bool]:
+def fulfill_skus(
+    db: Session,
+    order_id: str,
+    items: list[dict[str, int]],
+    *,
+    canonical: bool = False,
+) -> dict[str, Any]:
     normalized_payload = _normalized_payload(order_id, items)
     normalized_items = normalized_payload["items"]
     request_hash = _request_hash(normalized_payload)
 
     existing_operation = db.get(FulfilledOrder, order_id)
     if existing_operation is not None:
-        return _cached_response_or_conflict(existing_operation, request_hash)
+        return _cached_response_or_conflict(existing_operation, request_hash, canonical=canonical)
 
     response = {"ok": True}
     operation = FulfilledOrder(
@@ -79,7 +107,7 @@ def fulfill_skus(db: Session, order_id: str, items: list[dict[str, int]]) -> dic
         existing_operation = db.get(FulfilledOrder, order_id)
         if existing_operation is None:
             raise FulfillmentIdempotencyConflictError("order_id is currently being processed")
-        return _cached_response_or_conflict(existing_operation, request_hash)
+        return _cached_response_or_conflict(existing_operation, request_hash, canonical=canonical)
 
     sku_ids = [item["sku_id"] for item in normalized_items]
     sku_map = _lock_skus(db, sku_ids)
@@ -95,4 +123,7 @@ def fulfill_skus(db: Session, order_id: str, items: list[dict[str, int]]) -> dic
         sku.reserved_quantity -= item["quantity"]
 
     db.commit()
+    if canonical:
+        db.refresh(operation)
+        return _canonical_fulfillment_response(operation)
     return response

--- a/tests/api/test_fulfillment.py
+++ b/tests/api/test_fulfillment.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
@@ -55,13 +57,13 @@ def create_sku(
 def fulfill_payload(order_id: str, sku: SKU, quantity: int = 2) -> dict:
     return {
         "order_id": order_id,
-        "items": [{"sku_id": sku.id, "quantity": quantity}],
+        "items": [{"sku_id": str(sku.id), "quantity": quantity}],
     }
 
 
 def assert_sku_quantities(
     db_session: Session,
-    sku_id: int,
+    sku_id: UUID,
     *,
     active_quantity: int,
     reserved_quantity: int,
@@ -270,8 +272,8 @@ def test_insufficient_reserved_quantity_rolls_back_all_items(
         json={
             "order_id": "order-insufficient-reserve",
             "items": [
-                {"sku_id": enough_sku.id, "quantity": 2},
-                {"sku_id": low_sku.id, "quantity": 2},
+                {"sku_id": str(enough_sku.id), "quantity": 2},
+                {"sku_id": str(low_sku.id), "quantity": 2},
             ],
         },
         headers=service_headers(),

--- a/tests/api/test_fulfillment.py
+++ b/tests/api/test_fulfillment.py
@@ -1,0 +1,243 @@
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from src.core.config import settings
+from src.models import FulfilledOrder, Product, ProductImage, ProductStatus, SKU
+
+
+SELLER_ID = "c3d4e5f6-a7b8-9012-cdef-123456789012"
+
+
+def service_headers() -> dict[str, str]:
+    return {"X-Service-Key": settings.b2c_to_b2b_key}
+
+
+def create_product(db_session: Session, category_factory) -> Product:
+    category = category_factory()
+    product = Product(
+        title="iPhone 15 Pro Max",
+        description="Flagship smartphone",
+        seller_id=SELLER_ID,
+        category_id=category.id,
+        status=ProductStatus.MODERATED,
+    )
+    product.images = [ProductImage(url="/s3/iphone15-front.jpg", ordering=0)]
+    db_session.add(product)
+    db_session.commit()
+    db_session.refresh(product)
+    return product
+
+
+def create_sku(
+    db_session: Session,
+    product: Product,
+    *,
+    name: str = "128GB Black",
+    active_quantity: int = 0,
+    reserved_quantity: int = 0,
+) -> SKU:
+    sku = SKU(
+        product_id=product.id,
+        name=name,
+        price=9999000,
+        cost_price=7000000,
+        discount=0,
+        image="/s3/iphone15-black-128.jpg",
+        active_quantity=active_quantity,
+        reserved_quantity=reserved_quantity,
+    )
+    db_session.add(sku)
+    db_session.commit()
+    db_session.refresh(sku)
+    return sku
+
+
+def fulfill_payload(order_id: str, sku: SKU, quantity: int = 2) -> dict:
+    return {
+        "order_id": order_id,
+        "items": [{"sku_id": sku.id, "quantity": quantity}],
+    }
+
+
+def assert_sku_quantities(
+    db_session: Session,
+    sku_id: int,
+    *,
+    active_quantity: int,
+    reserved_quantity: int,
+) -> None:
+    db_session.expire_all()
+    sku = db_session.get(SKU, sku_id)
+    assert sku.active_quantity == active_quantity
+    assert sku.reserved_quantity == reserved_quantity
+
+
+def fulfilled_order_count(db_session: Session) -> int:
+    return db_session.scalar(select(func.count(FulfilledOrder.order_id))) or 0
+
+
+def test_fulfill_decreases_reserved_quantity(client, db_session: Session, category_factory):
+    product = create_product(db_session, category_factory)
+    sku = create_sku(db_session, product, active_quantity=7, reserved_quantity=5)
+
+    response = client.post(
+        "/api/v1/fulfill",
+        json=fulfill_payload("order-fulfill-decrease", sku, 2),
+        headers=service_headers(),
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    assert_sku_quantities(db_session, sku.id, active_quantity=7, reserved_quantity=3)
+    assert fulfilled_order_count(db_session) == 1
+
+
+def test_active_quantity_unchanged(client, db_session: Session, category_factory):
+    product = create_product(db_session, category_factory)
+    sku = create_sku(db_session, product, active_quantity=11, reserved_quantity=4)
+
+    response = client.post(
+        "/api/v1/fulfill",
+        json=fulfill_payload("order-active-unchanged", sku, 3),
+        headers=service_headers(),
+    )
+
+    assert response.status_code == 200
+    assert_sku_quantities(db_session, sku.id, active_quantity=11, reserved_quantity=1)
+
+
+def test_idempotent_fulfill_no_double_deduction(
+    client,
+    db_session: Session,
+    category_factory,
+):
+    product = create_product(db_session, category_factory)
+    sku = create_sku(db_session, product, active_quantity=8, reserved_quantity=6)
+    payload = fulfill_payload("order-idempotent-fulfill", sku, 2)
+
+    first_response = client.post("/api/v1/fulfill", json=payload, headers=service_headers())
+    second_response = client.post("/api/v1/fulfill", json=payload, headers=service_headers())
+
+    assert first_response.status_code == 200
+    assert second_response.status_code == 200
+    assert second_response.json() == first_response.json()
+    assert_sku_quantities(db_session, sku.id, active_quantity=8, reserved_quantity=4)
+    assert fulfilled_order_count(db_session) == 1
+
+
+def test_missing_service_key_returns_401(client, db_session: Session, category_factory):
+    product = create_product(db_session, category_factory)
+    sku = create_sku(db_session, product, active_quantity=5, reserved_quantity=3)
+
+    response = client.post(
+        "/api/v1/fulfill",
+        json=fulfill_payload("order-missing-service-key", sku, 1),
+    )
+
+    assert response.status_code == 401
+    assert response.json() == {"code": "UNAUTHORIZED", "message": "Authorization required"}
+    assert_sku_quantities(db_session, sku.id, active_quantity=5, reserved_quantity=3)
+    assert fulfilled_order_count(db_session) == 0
+
+
+def test_same_order_id_with_different_payload_returns_409(
+    client,
+    db_session: Session,
+    category_factory,
+):
+    product = create_product(db_session, category_factory)
+    sku = create_sku(db_session, product, active_quantity=8, reserved_quantity=6)
+
+    first_response = client.post(
+        "/api/v1/fulfill",
+        json=fulfill_payload("order-conflicting-payload", sku, 1),
+        headers=service_headers(),
+    )
+    second_response = client.post(
+        "/api/v1/fulfill",
+        json=fulfill_payload("order-conflicting-payload", sku, 2),
+        headers=service_headers(),
+    )
+
+    assert first_response.status_code == 200
+    assert second_response.status_code == 409
+    assert second_response.json() == {
+        "code": "CONFLICT",
+        "message": "order_id was already used with a different payload",
+    }
+    assert_sku_quantities(db_session, sku.id, active_quantity=8, reserved_quantity=5)
+    assert fulfilled_order_count(db_session) == 1
+
+
+def test_insufficient_reserved_quantity_rolls_back_all_items(
+    client,
+    db_session: Session,
+    category_factory,
+):
+    product = create_product(db_session, category_factory)
+    enough_sku = create_sku(db_session, product, active_quantity=4, reserved_quantity=3)
+    low_sku = create_sku(
+        db_session,
+        product,
+        name="256GB Black",
+        active_quantity=5,
+        reserved_quantity=1,
+    )
+
+    response = client.post(
+        "/api/v1/fulfill",
+        json={
+            "order_id": "order-insufficient-reserve",
+            "items": [
+                {"sku_id": enough_sku.id, "quantity": 2},
+                {"sku_id": low_sku.id, "quantity": 2},
+            ],
+        },
+        headers=service_headers(),
+    )
+
+    assert response.status_code == 409
+    assert response.json() == {
+        "code": "CONFLICT",
+        "message": "Insufficient reserved quantity",
+    }
+    assert_sku_quantities(db_session, enough_sku.id, active_quantity=4, reserved_quantity=3)
+    assert_sku_quantities(db_session, low_sku.id, active_quantity=5, reserved_quantity=1)
+    assert fulfilled_order_count(db_session) == 0
+
+
+def test_invalid_quantity_returns_400(client, db_session: Session, category_factory):
+    product = create_product(db_session, category_factory)
+    sku = create_sku(db_session, product, active_quantity=5, reserved_quantity=3)
+
+    response = client.post(
+        "/api/v1/fulfill",
+        json=fulfill_payload("order-invalid-quantity", sku, 0),
+        headers=service_headers(),
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"code": "INVALID_REQUEST", "message": "quantity must be > 0"}
+    assert_sku_quantities(db_session, sku.id, active_quantity=5, reserved_quantity=3)
+    assert fulfilled_order_count(db_session) == 0
+
+
+def test_seller_jwt_without_service_key_returns_401(
+    client,
+    db_session: Session,
+    category_factory,
+    auth_headers,
+):
+    product = create_product(db_session, category_factory)
+    sku = create_sku(db_session, product, active_quantity=5, reserved_quantity=3)
+
+    response = client.post(
+        "/api/v1/fulfill",
+        json=fulfill_payload("order-seller-jwt-only", sku, 1),
+        headers=auth_headers(SELLER_ID),
+    )
+
+    assert response.status_code == 401
+    assert response.json() == {"code": "UNAUTHORIZED", "message": "Authorization required"}
+    assert_sku_quantities(db_session, sku.id, active_quantity=5, reserved_quantity=3)
+    assert fulfilled_order_count(db_session) == 0

--- a/tests/api/test_fulfillment.py
+++ b/tests/api/test_fulfillment.py
@@ -76,6 +76,87 @@ def fulfilled_order_count(db_session: Session) -> int:
     return db_session.scalar(select(func.count(FulfilledOrder.order_id))) or 0
 
 
+def test_inventory_fulfill_returns_openapi_response(client, db_session: Session, category_factory):
+    product = create_product(db_session, category_factory)
+    sku = create_sku(db_session, product, active_quantity=7, reserved_quantity=5)
+
+    response = client.post(
+        "/api/v1/inventory/fulfill",
+        json=fulfill_payload("order-inventory-fulfill", sku, 2),
+        headers=service_headers(),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["order_id"] == "order-inventory-fulfill"
+    assert body["status"] == "FULFILLED"
+    assert body["processed_at"]
+    assert_sku_quantities(db_session, sku.id, active_quantity=7, reserved_quantity=3)
+    assert fulfilled_order_count(db_session) == 1
+
+
+def test_inventory_fulfill_idempotent_replay_returns_same_response_without_double_deduction(
+    client,
+    db_session: Session,
+    category_factory,
+):
+    product = create_product(db_session, category_factory)
+    sku = create_sku(db_session, product, active_quantity=8, reserved_quantity=6)
+    payload = fulfill_payload("order-inventory-idempotent", sku, 2)
+
+    first_response = client.post(
+        "/api/v1/inventory/fulfill",
+        json=payload,
+        headers=service_headers(),
+    )
+    second_response = client.post(
+        "/api/v1/inventory/fulfill",
+        json=payload,
+        headers=service_headers(),
+    )
+
+    assert first_response.status_code == 200
+    assert second_response.status_code == 200
+    assert second_response.json() == first_response.json()
+    assert_sku_quantities(db_session, sku.id, active_quantity=8, reserved_quantity=4)
+    assert fulfilled_order_count(db_session) == 1
+
+
+def test_inventory_fulfill_missing_service_key_returns_401(
+    client,
+    db_session: Session,
+    category_factory,
+):
+    product = create_product(db_session, category_factory)
+    sku = create_sku(db_session, product, active_quantity=5, reserved_quantity=3)
+
+    response = client.post(
+        "/api/v1/inventory/fulfill",
+        json=fulfill_payload("order-inventory-missing-service-key", sku, 1),
+    )
+
+    assert response.status_code == 401
+    assert response.json() == {"code": "UNAUTHORIZED", "message": "Authorization required"}
+    assert_sku_quantities(db_session, sku.id, active_quantity=5, reserved_quantity=3)
+    assert fulfilled_order_count(db_session) == 0
+
+
+def test_legacy_fulfill_route_still_returns_ok(client, db_session: Session, category_factory):
+    product = create_product(db_session, category_factory)
+    sku = create_sku(db_session, product, active_quantity=7, reserved_quantity=5)
+
+    response = client.post(
+        "/api/v1/fulfill",
+        json=fulfill_payload("order-legacy-fulfill", sku, 2),
+        headers=service_headers(),
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    assert_sku_quantities(db_session, sku.id, active_quantity=7, reserved_quantity=3)
+    assert fulfilled_order_count(db_session) == 1
+
+
 def test_fulfill_decreases_reserved_quantity(client, db_session: Session, category_factory):
     product = create_product(db_session, category_factory)
     sku = create_sku(db_session, product, active_quantity=7, reserved_quantity=5)


### PR DESCRIPTION
# US-B2B-10 Summary

US-B2B-10 is migrated to the final authoritative `flow/openapi.yaml` inventory fulfill contract. For the affected fulfill endpoint, this contract matches the previously reviewed `neomarket-b2b.yaml` inventory fulfill contract.

Added canonical `POST /api/v1/inventory/fulfill` while keeping legacy `POST /api/v1/fulfill` on top of the stacked US-B2B-01 through US-B2B-09 changes. This slice depends on US-B2B-01 through US-B2B-09 until those changes are merged.

Fulfill is a B2C service-to-service endpoint and authenticates only with `X-Service-Key == settings.b2c_to_b2b_key`, matching `flow/openapi.yaml`. Seller JWTs are not required and are not accepted as a substitute. Missing or invalid service keys return `401 {"code":"UNAUTHORIZED","message":"Authorization required"}`.

The request shape follows the canonical flow field names:

```json
{
  "order_id": "order-id",
  "items": [
    {"sku_id": 1, "quantity": 2}
  ]
}
```

Route-local validation requires `order_id`, a non-empty `items` list, positive integer `sku_id`, and `quantity > 0`, returning canonical `400 INVALID_REQUEST` errors instead of FastAPI `422`. The OpenAPI examples show UUID-shaped IDs, but this service currently uses integer SKU primary keys consistently with reserve/unreserve, so fulfill keeps integer `sku_id`.

Fulfill finalizes an existing delivered order/reservation by decreasing `reserved_quantity` only:

- `reserved_quantity -= quantity`
- `active_quantity` remains unchanged
- `active_quantity + reserved_quantity` intentionally decreases because delivered goods have physically left stock
- `flow/openapi.yaml` mentions `stock_quantity`; this codebase maps buyer-visible stock through `active_quantity`, and fulfill finalizes reserved stock by decreasing `reserved_quantity` only
- no stock restore
- no order creation/cancellation
- no product moderation state changes
- no stock acceptance or invoice events
- no invoice `accepted_quantity` mutation

Fulfill validates SKU existence and sufficient `reserved_quantity`; it does not require current catalog visibility. This follows the lifecycle assumption that fulfill acts on an already-created order/reservation and must still be able to complete if product visibility changed after checkout.

Added `fulfilled_orders`, keyed by `order_id`, with `request_hash`, normalized `request_payload`, cached legacy success `response`, and `created_at`. The fulfilled order record is written in the same DB transaction as the reserved stock deductions. Replaying the same `order_id` with the same normalized payload returns without double deduction. The canonical route returns `200 {"order_id":"...","status":"FULFILLED","processed_at":"..."}` with `processed_at` derived from persisted `fulfilled_orders.created_at`, so replay returns the same timestamp. The legacy route keeps returning cached `200 {"ok": true}`. Reusing the same `order_id` with a different payload returns `409 CONFLICT`; the flow only defines same-order retry behavior, so this conflict behavior is an explicit implementation assumption.

Fulfill is atomic across all requested items. The service claims the `order_id`, locks requested SKUs with `SELECT FOR UPDATE` where supported, validates every item, deducts all reserved quantities, stores the success response, and commits. If any item is missing or has insufficient reserved quantity, the transaction rolls back, no fulfilled-order success record is written, and no SKU is partially fulfilled. SQLite tests do not enforce row locks, but PostgreSQL uses the generated `SELECT FOR UPDATE`; deterministic tests cover rollback/all-or-nothing behavior.

No US-B2B-11+ behavior is included: no seller list migration and no SKU delete behavior.

# US-B2B-10 Validation

Pytest proof command:

```powershell
python -m pytest tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py tests/api/test_reservations.py tests/api/test_moderation_events.py tests/api/test_fulfillment.py -vv
```

Required scenario results:

- `test_inventory_fulfill_returns_openapi_response`: passed
- `test_inventory_fulfill_idempotent_replay_returns_same_response_without_double_deduction`: passed
- `test_inventory_fulfill_missing_service_key_returns_401`: passed
- `test_legacy_fulfill_route_still_returns_ok`: passed

Additional safety results:

- `test_fulfill_decreases_reserved_quantity`: passed
- `test_active_quantity_unchanged`: passed
- `test_idempotent_fulfill_no_double_deduction`: passed
- `test_missing_service_key_returns_401`: passed
- `test_same_order_id_with_different_payload_returns_409`: passed
- `test_insufficient_reserved_quantity_rolls_back_all_items`: passed
- `test_invalid_quantity_returns_400`: passed
- `test_seller_jwt_without_service_key_returns_401`: passed

Suite results:

- `tests/api/test_fulfillment.py`: 12 passed
- Required US-B2B-10 OpenAPI migration scenarios: 4 passed
- `tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py tests/api/test_reservations.py tests/api/test_moderation_events.py tests/api/test_fulfillment.py`: 99 passed

# ADR: Fulfill Idempotency by Order ID

Options considered:

- DB-backed `fulfilled_orders` table keyed by `order_id`: selected. It has moderate implementation complexity, but gives the lowest double-deduction risk on retries because the request hash, normalized payload, cached response, and successful fulfillment are persisted across process restarts.
- `last_fulfilled_order` field on SKU: lower implementation complexity, but unsafe for multi-SKU orders and payload conflict detection. It cannot represent order-level idempotency cleanly and risks inconsistent retry behavior.
- Checking `reserved_quantity` only: lowest implementation complexity, but not true idempotency. It cannot distinguish a legitimate retry from a conflicting request and can produce false success or double-deduction risk under concurrent/retried calls.

Decision: use a persisted `fulfilled_orders` table. The service claims `order_id`, locks all requested SKUs with `SELECT FOR UPDATE` where supported, validates all items, deducts `reserved_quantity`, stores the cached success response, and commits in one transaction. Validation and stock conflicts roll back the idempotency row and stock changes, so failed fulfill attempts are not replay-cached.