### PR TITLE
US-B2B-11: Implement seller product list

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -680,3 +680,55 @@ Decision: use a persisted `fulfilled_orders` table. The service claims `order_id
 After the UUID migration, fulfillment HTTP request bodies must carry `sku_id` as JSON strings because real clients cannot send Python `uuid.UUID` objects. Both canonical `/api/v1/inventory/fulfill` and legacy `/api/v1/fulfill` parse those strings into `uuid.UUID` instances for service and SQLAlchemy lookups, while persisted idempotency payloads serialize SKU identifiers back to strings.
 
 Decision: keep fulfillment schemas, routing, and service logic UUID-aware, remove integer SKU parsing from fulfill normalization, and update fulfillment tests to send `str(sku.id)` in all JSON payloads. Fulfillment idempotency, service-key authentication, reserved stock deduction, active stock behavior, and all-or-nothing rollback behavior are unchanged.
+
+---
+
+# US-B2B-11 Summary
+
+Implemented seller product list enhancements on top of the stacked US-B2B-01 through US-B2B-10 changes. This PR depends on US-B2B-01 through US-B2B-10 until those changes are merged.
+
+`GET /api/v1/products` keeps the existing mode routing: a valid `X-Service-Key` uses B2C catalog mode, an invalid service key returns `401`, and no service key requires a seller Bearer JWT for seller-list mode. Seller-list mode takes `seller_id` only from JWT claims and ignores ownership query parameters such as `seller_id`, `sellerId`, `owner_id`, and `user_id`.
+
+Seller-list mode now returns only the authenticated seller's products, includes deleted products with `deleted: true`, supports `limit`/`offset` bounds, exact `status` filtering, and case-insensitive trimmed title `search`. Invalid `status` returns `400 {"code":"INVALID_REQUEST","message":"status must be valid"}`. B2C catalog behavior is unchanged and still excludes deleted products.
+
+The seller-list response now uses a dedicated schema with `id`, `title`, `status`, `deleted`, `category`, `images`, `skus_count`, `total_active_quantity`, and `created_at`, plus top-level `items`, `total_count`, `limit`, and `offset`.
+
+OpenAPI gap: `flow/b2b.yaml` is stale for this story. It documents `/api/products/my` and does not match the canonical `GET /api/v1/products` seller-list contract in `flow/b2b-flows.md#list-products`, so `flow/*` was left unchanged.
+
+Deleted visibility note: US-B2B-11 supersedes US-B2B-04's earlier minimal seller-list behavior. Seller list now includes deleted products, while B2C catalog still excludes them.
+
+No migration is needed.
+
+# US-B2B-11 Validation
+
+Pytest proof commands:
+
+```powershell
+python -m pytest tests/api/test_products.py -vv -k "test_list_returns_only_own_products or test_idor_query_param_seller_id_ignored or test_deleted_products_visible_with_deleted_flag or test_status_filter_works_correctly or test_search_by_title_case_insensitive"
+python -m pytest tests/api/test_products.py -vv -k "catalog_returns_moderated_in_stock_products or catalog_excludes_hard_blocked or catalog_missing_service_key_returns_401 or catalog_response_has_no_cost_price or batch_ids_returns_visible_subset or get_moderated_product_returns_full_payload or get_others_product_returns_404"
+python -m pytest tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py tests/api/test_reservations.py tests/api/test_moderation_events.py tests/api/test_fulfillment.py -vv
+```
+
+Required scenario results:
+
+- `test_list_returns_only_own_products`: passed
+- `test_idor_query_param_seller_id_ignored`: passed
+- `test_deleted_products_visible_with_deleted_flag`: passed
+- `test_status_filter_works_correctly`: passed
+- `test_search_by_title_case_insensitive`: passed
+
+Regression results:
+
+- Required US-B2B-11 scenarios: 5 passed, 19 deselected
+- Catalog/detail regression selection: 7 passed, 17 deselected
+- `tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py tests/api/test_reservations.py tests/api/test_moderation_events.py tests/api/test_fulfillment.py`: 69 passed
+
+# ADR: Seller List SKU Aggregates
+
+Options considered:
+
+- SQL aggregate count/sum: selected. It avoids N+1 queries, keeps list responses bounded as SKU counts grow, and fits the existing SQLAlchemy service layer with moderate maintenance cost.
+- Prefetch and compute in serializer/service: simpler at first, but risks loading unnecessary SKU rows for every product as list size grows.
+- Raw SQL: efficient, but higher maintenance and less consistent with the existing ORM service style.
+
+Decision: use a grouped SQLAlchemy aggregate subquery over `SKU.product_id`, with an outer join from products so products without SKUs return `skus_count=0` and `total_active_quantity=0`.

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -685,27 +685,27 @@ Decision: keep fulfillment schemas, routing, and service logic UUID-aware, remov
 
 # US-B2B-11 Summary
 
-Implemented seller product list enhancements on top of the stacked US-B2B-01 through US-B2B-10 changes. This PR depends on US-B2B-01 through US-B2B-10 until those changes are merged.
+US-B2B-11 is migrated to the final authoritative `flow/openapi.yaml` seller product list contract. For the affected seller product list endpoint, this contract matches the previously reviewed `neomarket-b2b.yaml` seller product list contract.
 
 `GET /api/v1/products` keeps the existing mode routing: a valid `X-Service-Key` uses B2C catalog mode, an invalid service key returns `401`, and no service key requires a seller Bearer JWT for seller-list mode. Seller-list mode takes `seller_id` only from JWT claims and ignores ownership query parameters such as `seller_id`, `sellerId`, `owner_id`, and `user_id`.
 
-Seller-list mode now returns only the authenticated seller's products, includes deleted products with `deleted: true`, supports `limit`/`offset` bounds, exact `status` filtering, and case-insensitive trimmed title `search`. Invalid `status` returns `400 {"code":"INVALID_REQUEST","message":"status must be valid"}`. B2C catalog behavior is unchanged and still excludes deleted products.
+Seller-list mode now returns only the authenticated seller's products, supports `limit`/`offset` bounds, exact `status` filtering, case-insensitive trimmed title `search`, and `include_deleted`. Invalid `status` returns `400 {"code":"INVALID_REQUEST","message":"status must be valid"}`. B2C catalog behavior is unchanged and still excludes deleted products.
 
-The seller-list response now uses a dedicated schema with `id`, `title`, `status`, `deleted`, `category`, `images`, `skus_count`, `total_active_quantity`, and `created_at`, plus top-level `items`, `total_count`, `limit`, and `offset`.
+`include_deleted=false` is the new default, including when the query parameter is omitted. It hides soft-deleted products from seller-list results. `include_deleted=true` is the explicit compatibility path for the old deleted-visible seller-list behavior.
 
-OpenAPI gap: `flow/b2b.yaml` is stale for this story. It documents `/api/products/my` and does not match the canonical `GET /api/v1/products` seller-list contract in `flow/b2b-flows.md#list-products`, so `flow/*` was left unchanged.
-
-Deleted visibility note: US-B2B-11 supersedes US-B2B-04's earlier minimal seller-list behavior. Seller list now includes deleted products, while B2C catalog still excludes them.
+Seller-list items now use the `ProductShortResponse`-style response shape: stringified `id`, `title`, `slug`, `status`, stringified `category_id`, `deleted`, `created_at`, `min_price`, and `cover_image`. The seller-list keeps the existing aggregate extensions `skus_count` and `total_active_quantity`. Seller-only or old nested fields such as `seller_id`, `category`, `images`, SKU `cost_price`, and `reserved_quantity` are not exposed in list items.
 
 No migration is needed.
+
+No US-B2B-12+ behavior is included: SKU delete behavior and SKU deleted filtering are unchanged.
 
 # US-B2B-11 Validation
 
 Pytest proof commands:
 
 ```powershell
-python -m pytest tests/api/test_products.py -vv -k "test_list_returns_only_own_products or test_idor_query_param_seller_id_ignored or test_deleted_products_visible_with_deleted_flag or test_status_filter_works_correctly or test_search_by_title_case_insensitive"
-python -m pytest tests/api/test_products.py -vv -k "catalog_returns_moderated_in_stock_products or catalog_excludes_hard_blocked or catalog_missing_service_key_returns_401 or catalog_response_has_no_cost_price or batch_ids_returns_visible_subset or get_moderated_product_returns_full_payload or get_others_product_returns_404"
+python -m pytest tests/api/test_products.py -vv -k "test_list_returns_only_own_products or test_idor_query_param_seller_id_ignored or test_deleted_products_hidden_by_default or test_include_deleted_true_returns_deleted_products or test_status_filter_works_correctly or test_search_by_title_case_insensitive"
+python -m pytest tests/api/test_products.py -vv
 python -m pytest tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py tests/api/test_reservations.py tests/api/test_moderation_events.py tests/api/test_fulfillment.py -vv
 ```
 
@@ -713,15 +713,16 @@ Required scenario results:
 
 - `test_list_returns_only_own_products`: passed
 - `test_idor_query_param_seller_id_ignored`: passed
-- `test_deleted_products_visible_with_deleted_flag`: passed
+- `test_deleted_products_hidden_by_default`: passed
+- `test_include_deleted_true_returns_deleted_products`: passed
 - `test_status_filter_works_correctly`: passed
 - `test_search_by_title_case_insensitive`: passed
 
 Regression results:
 
-- Required US-B2B-11 scenarios: 5 passed, 19 deselected
-- Catalog/detail regression selection: 7 passed, 17 deselected
-- `tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py tests/api/test_reservations.py tests/api/test_moderation_events.py tests/api/test_fulfillment.py`: 69 passed
+- Required US-B2B-11 scenarios: 6 passed, 30 deselected
+- `tests/api/test_products.py`: 36 passed
+- `tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py tests/api/test_reservations.py tests/api/test_moderation_events.py tests/api/test_fulfillment.py`: 104 passed
 
 # ADR: Seller List SKU Aggregates
 

--- a/src/api/routes/products.py
+++ b/src/api/routes/products.py
@@ -14,15 +14,17 @@ from src.api.deps import (
 )
 from src.core.config import settings
 from src.db.session import get_db
+from src.models import ProductStatus
 from src.schemas.product import (
     ProductCreate,
     ProductCreateRead,
-    ProductListRead,
     ProductPublicPaginatedResponse,
     ProductPublicRead,
     ProductResponse,
     ProductPublicShortRead,
     ProductUpdate,
+    SellerProductListItemRead,
+    SellerProductListRead,
     SellerProductRead,
 )
 from src.services.errors import NotFoundError
@@ -92,15 +94,34 @@ async def create_product_endpoint(
         return _field_validation_error(exc.field, exc.message)
 
 
-@router.get("", response_model=ProductListRead | ProductPublicPaginatedResponse, status_code=status.HTTP_200_OK)
+def _seller_product_list_item(item) -> SellerProductListItemRead:
+    product = item.product
+    return SellerProductListItemRead.model_validate(
+        {
+            "id": product.id,
+            "title": product.title,
+            "status": product.status,
+            "deleted": product.deleted,
+            "category": product.category,
+            "images": product.images,
+            "skus_count": item.skus_count,
+            "total_active_quantity": item.total_active_quantity,
+            "created_at": product.created_at,
+        }
+    )
+
+
+@router.get("", response_model=SellerProductListRead | ProductPublicPaginatedResponse, status_code=status.HTTP_200_OK)
 def list_products_endpoint(
     limit: int = 20,
     offset: int = 0,
     ids: list[str] | None = Query(default=None),
+    product_status: str | None = Query(default=None, alias="status"),
+    search: str | None = Query(default=None),
     service_key: str | None = Header(default=None, alias="X-Service-Key"),
     token: str | None = Depends(oauth2_scheme),
     db: Session = Depends(get_db),
-) -> ProductListRead | ProductPublicPaginatedResponse | JSONResponse:
+) -> SellerProductListRead | ProductPublicPaginatedResponse | JSONResponse:
     bounded_limit = min(max(limit, 1), 100)
     bounded_offset = max(offset, 0)
 
@@ -133,14 +154,23 @@ def list_products_endpoint(
     if isinstance(current_seller, JSONResponse):
         return current_seller
 
+    status_filter = None
+    if product_status is not None:
+        try:
+            status_filter = ProductStatus(product_status)
+        except ValueError:
+            return _invalid_request("status must be valid")
+
     products, total_count = list_seller_products(
         db,
         current_seller.seller_id,
         limit=bounded_limit,
         offset=bounded_offset,
+        product_status=status_filter,
+        search=search,
     )
-    return ProductListRead(
-        items=products,
+    return SellerProductListRead(
+        items=[_seller_product_list_item(product) for product in products],
         total_count=total_count,
         limit=bounded_limit,
         offset=bounded_offset,

--- a/src/api/routes/products.py
+++ b/src/api/routes/products.py
@@ -1,3 +1,4 @@
+import re
 import uuid
 
 from fastapi import APIRouter, Depends, Header, Query, Response, status
@@ -96,14 +97,17 @@ async def create_product_endpoint(
 
 def _seller_product_list_item(item) -> SellerProductListItemRead:
     product = item.product
+    slug_value = re.sub(r"[^a-z0-9]+", "-", product.title.lower()).strip("-")
     return SellerProductListItemRead.model_validate(
         {
             "id": product.id,
             "title": product.title,
+            "slug": f"{slug_value or 'product'}-{product.id}",
             "status": product.status,
+            "category_id": product.category_id,
             "deleted": product.deleted,
-            "category": product.category,
-            "images": product.images,
+            "min_price": item.min_price,
+            "cover_image": product.images[0].url if product.images else None,
             "skus_count": item.skus_count,
             "total_active_quantity": item.total_active_quantity,
             "created_at": product.created_at,
@@ -118,6 +122,7 @@ def list_products_endpoint(
     ids: list[str] | None = Query(default=None),
     product_status: str | None = Query(default=None, alias="status"),
     search: str | None = Query(default=None),
+    include_deleted: bool = Query(default=False),
     service_key: str | None = Header(default=None, alias="X-Service-Key"),
     token: str | None = Depends(oauth2_scheme),
     db: Session = Depends(get_db),
@@ -168,6 +173,7 @@ def list_products_endpoint(
         offset=bounded_offset,
         product_status=status_filter,
         search=search,
+        include_deleted=include_deleted,
     )
     return SellerProductListRead(
         items=[_seller_product_list_item(product) for product in products],

--- a/src/schemas/product.py
+++ b/src/schemas/product.py
@@ -325,8 +325,27 @@ class PublicProductBatchRequest(APIModel):
     product_ids: list[str] = Field(max_length=100)
 
 
+class SellerProductListItemRead(APIModel):
+    id: uuid.UUID
+    title: str
+    status: str
+    deleted: bool
+    category: CategoryOut
+    images: list[ImageOut] = Field(default_factory=list)
+    skus_count: int
+    total_active_quantity: int
+    created_at: datetime
+
+
 class ProductListRead(APIModel):
     items: list[ProductRead]
+    total_count: int
+    limit: int
+    offset: int
+
+
+class SellerProductListRead(APIModel):
+    items: list[SellerProductListItemRead]
     total_count: int
     limit: int
     offset: int

--- a/src/schemas/product.py
+++ b/src/schemas/product.py
@@ -330,17 +330,13 @@ class SellerProductListItemRead(APIModel):
     title: str
     slug: str
     status: str
-    category_id: int
+    category_id: uuid.UUID
     deleted: bool
     min_price: int | None = None
     cover_image: str | None = None
     skus_count: int
     total_active_quantity: int
     created_at: datetime
-
-    @field_serializer("id", "category_id")
-    def serialize_id(self, value: int) -> str:
-        return str(value)
 
 
 class ProductListRead(APIModel):

--- a/src/schemas/product.py
+++ b/src/schemas/product.py
@@ -328,13 +328,19 @@ class PublicProductBatchRequest(APIModel):
 class SellerProductListItemRead(APIModel):
     id: uuid.UUID
     title: str
+    slug: str
     status: str
+    category_id: int
     deleted: bool
-    category: CategoryOut
-    images: list[ImageOut] = Field(default_factory=list)
+    min_price: int | None = None
+    cover_image: str | None = None
     skus_count: int
     total_active_quantity: int
     created_at: datetime
+
+    @field_serializer("id", "category_id")
+    def serialize_id(self, value: int) -> str:
+        return str(value)
 
 
 class ProductListRead(APIModel):

--- a/src/services/product_service.py
+++ b/src/services/product_service.py
@@ -1,6 +1,7 @@
 import logging
 import uuid
 from collections.abc import Sequence
+from dataclasses import dataclass
 
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session, selectinload
@@ -38,6 +39,13 @@ class ProductAlreadyDeletedError(Exception):
 
 class ModerationUnavailableError(Exception):
     pass
+
+
+@dataclass(frozen=True)
+class SellerProductListItem:
+    product: Product
+    skus_count: int
+    total_active_quantity: int
 
 
 def _product_query():
@@ -93,17 +101,61 @@ def get_public_product_by_id(db: Session, product_id: uuid.UUID) -> Product:
     return product
 
 
-def list_seller_products(db: Session, seller_id: uuid.UUID, limit: int = 20, offset: int = 0) -> tuple[list[Product], int]:
-    filters = (Product.seller_id == seller_id, Product.deleted.is_(False))
+def list_seller_products(
+    db: Session,
+    seller_id: uuid.UUID,
+    limit: int = 20,
+    offset: int = 0,
+    *,
+    product_status: ProductStatus | None = None,
+    search: str | None = None,
+) -> tuple[list[SellerProductListItem], int]:
+    filters = [Product.seller_id == seller_id]
+    if product_status is not None:
+        filters.append(Product.status == product_status)
+
+    search_term = search.strip() if search else ""
+    if search_term:
+        filters.append(Product.title.ilike(f"%{search_term}%"))
+
     total_count = db.scalar(select(func.count(Product.id)).where(*filters)) or 0
-    products = db.scalars(
-        _product_query()
+
+    sku_aggregates = (
+        select(
+            SKU.product_id.label("product_id"),
+            func.count(SKU.id).label("skus_count"),
+            func.coalesce(func.sum(SKU.active_quantity), 0).label("total_active_quantity"),
+        )
+        .group_by(SKU.product_id)
+        .subquery()
+    )
+
+    rows = db.execute(
+        select(
+            Product,
+            func.coalesce(sku_aggregates.c.skus_count, 0).label("skus_count"),
+            func.coalesce(sku_aggregates.c.total_active_quantity, 0).label("total_active_quantity"),
+        )
+        .options(
+            selectinload(Product.category),
+            selectinload(Product.images),
+        )
+        .outerjoin(sku_aggregates, sku_aggregates.c.product_id == Product.id)
         .where(*filters)
         .order_by(Product.id)
         .offset(offset)
         .limit(limit)
     ).all()
-    return list(products), total_count
+
+    products = [
+        SellerProductListItem(
+            product=row[0],
+            skus_count=int(row.skus_count or 0),
+            total_active_quantity=int(row.total_active_quantity or 0),
+        )
+        for row in rows
+    ]
+    return products, total_count
 
 
 def list_catalog_products(

--- a/src/services/product_service.py
+++ b/src/services/product_service.py
@@ -46,6 +46,7 @@ class SellerProductListItem:
     product: Product
     skus_count: int
     total_active_quantity: int
+    min_price: int | None
 
 
 def _product_query():
@@ -109,8 +110,11 @@ def list_seller_products(
     *,
     product_status: ProductStatus | None = None,
     search: str | None = None,
+    include_deleted: bool = False,
 ) -> tuple[list[SellerProductListItem], int]:
     filters = [Product.seller_id == seller_id]
+    if not include_deleted:
+        filters.append(Product.deleted.is_(False))
     if product_status is not None:
         filters.append(Product.status == product_status)
 
@@ -125,6 +129,7 @@ def list_seller_products(
             SKU.product_id.label("product_id"),
             func.count(SKU.id).label("skus_count"),
             func.coalesce(func.sum(SKU.active_quantity), 0).label("total_active_quantity"),
+            func.min(SKU.price).label("min_price"),
         )
         .group_by(SKU.product_id)
         .subquery()
@@ -135,9 +140,9 @@ def list_seller_products(
             Product,
             func.coalesce(sku_aggregates.c.skus_count, 0).label("skus_count"),
             func.coalesce(sku_aggregates.c.total_active_quantity, 0).label("total_active_quantity"),
+            sku_aggregates.c.min_price.label("min_price"),
         )
         .options(
-            selectinload(Product.category),
             selectinload(Product.images),
         )
         .outerjoin(sku_aggregates, sku_aggregates.c.product_id == Product.id)
@@ -152,6 +157,7 @@ def list_seller_products(
             product=row[0],
             skus_count=int(row.skus_count or 0),
             total_active_quantity=int(row.total_active_quantity or 0),
+            min_price=row.min_price,
         )
         for row in rows
     ]

--- a/tests/api/test_products.py
+++ b/tests/api/test_products.py
@@ -114,12 +114,13 @@ def product_factory(db_session: Session, category_factory):
         seller_id: str = SELLER_ID,
         status: ProductStatus = ProductStatus.CREATED,
         deleted: bool = False,
+        title: str = "iPhone 15 Pro Max",
         blocking_reason: dict | None = None,
         field_reports: list[dict] | None = None,
     ) -> Product:
         category = category_factory()
         product = Product(
-            title="iPhone 15 Pro Max",
+            title=title,
             description="Flagship smartphone",
             seller_id=seller_id,
             category_id=category.id,
@@ -858,7 +859,77 @@ def test_delete_others_product_returns_403(
     assert test_event_requests == {"moderation": [], "b2c": []}
 
 
-def test_deleted_product_not_in_seller_list(
+def test_list_returns_only_own_products(
+    client,
+    db_session: Session,
+    test_product_factory,
+    auth_headers,
+):
+    own_product = test_product_factory()
+    create_existing_sku(db_session, own_product, active_quantity=5)
+    create_existing_sku(db_session, own_product, active_quantity=0)
+    own_product_without_skus = test_product_factory()
+    other_product = test_product_factory(seller_id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+
+    response = client.get("/api/v1/products", headers=auth_headers(SELLER_ID))
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total_count"] == 2
+    assert body["limit"] == 20
+    assert body["offset"] == 0
+    assert [item["id"] for item in body["items"]] == [str(own_product.id), str(own_product_without_skus.id)]
+    assert str(other_product.id) not in [item["id"] for item in body["items"]]
+
+    first_item = body["items"][0]
+    assert first_item["title"] == own_product.title
+    assert first_item["status"] == "CREATED"
+    assert first_item["deleted"] is False
+    assert first_item["category"] == {"id": str(own_product.category.id), "name": own_product.category.name}
+    assert first_item["images"] == [
+        {
+            "id": str(own_product.images[0].id),
+            "url": "/s3/iphone15-front.jpg",
+            "ordering": 0,
+        }
+    ]
+    assert first_item["skus_count"] == 2
+    assert first_item["total_active_quantity"] == 5
+    assert "created_at" in first_item
+
+    second_item = body["items"][1]
+    assert second_item["skus_count"] == 0
+    assert second_item["total_active_quantity"] == 0
+
+
+def test_idor_query_param_seller_id_ignored(
+    client,
+    test_product_factory,
+    auth_headers,
+):
+    other_seller_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    own_product = test_product_factory()
+    other_product = test_product_factory(seller_id=other_seller_id)
+
+    response = client.get(
+        "/api/v1/products",
+        params={
+            "seller_id": other_seller_id,
+            "sellerId": other_seller_id,
+            "owner_id": other_seller_id,
+            "user_id": other_seller_id,
+        },
+        headers=auth_headers(SELLER_ID),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total_count"] == 1
+    assert [item["id"] for item in body["items"]] == [str(own_product.id)]
+    assert str(other_product.id) not in [item["id"] for item in body["items"]]
+
+
+def test_deleted_products_visible_with_deleted_flag(
     client,
     db_session: Session,
     test_product_factory,
@@ -880,11 +951,71 @@ def test_deleted_product_not_in_seller_list(
 
     assert list_response.status_code == 200
     body = list_response.json()
-    assert body["total_count"] == 1
-    assert [item["id"] for item in body["items"]] == [str(visible_product.id)]
+    assert body["total_count"] == 2
+    assert [item["id"] for item in body["items"]] == [str(visible_product.id), str(deleted_product.id)]
+    assert [item["deleted"] for item in body["items"]] == [False, True]
 
     db_session.refresh(deleted_product)
     assert deleted_product.deleted is True
+
+
+def test_status_filter_works_correctly(client, test_product_factory, auth_headers):
+    blocked_product = test_product_factory(status=ProductStatus.BLOCKED)
+    moderated_product = test_product_factory(status=ProductStatus.MODERATED)
+    other_blocked_product = test_product_factory(
+        seller_id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        status=ProductStatus.BLOCKED,
+    )
+
+    response = client.get(
+        "/api/v1/products",
+        params={"status": "BLOCKED"},
+        headers=auth_headers(SELLER_ID),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total_count"] == 1
+    assert [item["id"] for item in body["items"]] == [str(blocked_product.id)]
+    assert str(moderated_product.id) not in [item["id"] for item in body["items"]]
+    assert str(other_blocked_product.id) not in [item["id"] for item in body["items"]]
+
+    invalid_response = client.get(
+        "/api/v1/products",
+        params={"status": "NOT_A_STATUS"},
+        headers=auth_headers(SELLER_ID),
+    )
+    assert invalid_response.status_code == 400
+    assert invalid_response.json() == {
+        "code": "INVALID_REQUEST",
+        "message": "status must be valid",
+    }
+
+
+def test_search_by_title_case_insensitive(client, test_product_factory, auth_headers):
+    matching_product = test_product_factory(title="Wireless Keyboard")
+    another_matching_product = test_product_factory(title="compact KEYBOARD case")
+    non_matching_product = test_product_factory(title="Bluetooth Mouse")
+    other_seller_product = test_product_factory(
+        seller_id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        title="Keyboard for another seller",
+    )
+
+    response = client.get(
+        "/api/v1/products",
+        params={"search": "  keyboard  "},
+        headers=auth_headers(SELLER_ID),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total_count"] == 2
+    assert [item["id"] for item in body["items"]] == [
+        str(matching_product.id),
+        str(another_matching_product.id),
+    ]
+    assert str(non_matching_product.id) not in [item["id"] for item in body["items"]]
+    assert str(other_seller_product.id) not in [item["id"] for item in body["items"]]
 
 
 def test_public_catalog_returns_short_paginated_products(client, db_session: Session, test_product_factory):
@@ -951,7 +1082,7 @@ def test_public_catalog_excludes_non_moderated_deleted_and_out_of_stock(
     assert hidden_ids.isdisjoint({item["id"] for item in body["items"]})
 
 
-def test_public_catalog_requires_valid_service_key(client, db_session: Session, test_product_factory):
+def test_public_catalog_requires_valid_service_key(client, db_session: Session, test_product_factory, auth_headers):
     product = test_product_factory(status=ProductStatus.MODERATED)
     create_existing_sku(db_session, product, active_quantity=1)
 
@@ -962,6 +1093,13 @@ def test_public_catalog_requires_valid_service_key(client, db_session: Session, 
     invalid_response = client.get("/api/v1/public/products", headers={"X-Service-Key": "wrong"})
     assert invalid_response.status_code == 401
     assert invalid_response.json() == {"code": "UNAUTHORIZED", "message": "Authorization required"}
+
+    seller_response = client.get("/api/v1/products", headers=auth_headers(SELLER_ID))
+    assert seller_response.status_code == 200
+    seller_body = seller_response.json()
+    assert seller_body["total_count"] == 1
+    assert seller_body["items"][0]["id"] == str(product.id)
+    assert "seller_id" not in seller_body["items"][0]
 
 
 def test_public_catalog_response_has_no_seller_only_fields(client, db_session: Session, test_product_factory):

--- a/tests/api/test_products.py
+++ b/tests/api/test_products.py
@@ -882,22 +882,36 @@ def test_list_returns_only_own_products(
     assert str(other_product.id) not in [item["id"] for item in body["items"]]
 
     first_item = body["items"][0]
+    assert set(first_item) == {
+        "id",
+        "title",
+        "slug",
+        "status",
+        "category_id",
+        "deleted",
+        "min_price",
+        "cover_image",
+        "skus_count",
+        "total_active_quantity",
+        "created_at",
+    }
     assert first_item["title"] == own_product.title
+    assert first_item["slug"] == f"iphone-15-pro-max-{own_product.id}"
     assert first_item["status"] == "CREATED"
+    assert first_item["category_id"] == str(own_product.category_id)
     assert first_item["deleted"] is False
-    assert first_item["category"] == {"id": str(own_product.category.id), "name": own_product.category.name}
-    assert first_item["images"] == [
-        {
-            "id": str(own_product.images[0].id),
-            "url": "/s3/iphone15-front.jpg",
-            "ordering": 0,
-        }
-    ]
+    assert first_item["min_price"] == 9999000
+    assert first_item["cover_image"] == "/s3/iphone15-front.jpg"
     assert first_item["skus_count"] == 2
     assert first_item["total_active_quantity"] == 5
     assert "created_at" in first_item
+    assert "seller_id" not in first_item
+    assert "category" not in first_item
+    assert "images" not in first_item
 
     second_item = body["items"][1]
+    assert second_item["min_price"] is None
+    assert second_item["cover_image"] == "/s3/iphone15-front.jpg"
     assert second_item["skus_count"] == 0
     assert second_item["total_active_quantity"] == 0
 
@@ -929,7 +943,7 @@ def test_idor_query_param_seller_id_ignored(
     assert str(other_product.id) not in [item["id"] for item in body["items"]]
 
 
-def test_deleted_products_visible_with_deleted_flag(
+def test_deleted_products_hidden_by_default(
     client,
     db_session: Session,
     test_product_factory,
@@ -951,12 +965,40 @@ def test_deleted_products_visible_with_deleted_flag(
 
     assert list_response.status_code == 200
     body = list_response.json()
-    assert body["total_count"] == 2
-    assert [item["id"] for item in body["items"]] == [str(visible_product.id), str(deleted_product.id)]
-    assert [item["deleted"] for item in body["items"]] == [False, True]
+    assert body["total_count"] == 1
+    assert [item["id"] for item in body["items"]] == [str(visible_product.id)]
 
     db_session.refresh(deleted_product)
     assert deleted_product.deleted is True
+
+
+def test_include_deleted_true_returns_deleted_products(
+    client,
+    test_product_factory,
+    auth_headers,
+    test_event_requests,
+):
+    visible_product = test_product_factory()
+    deleted_product = test_product_factory()
+
+    response = client.delete(f"/api/v1/products/{deleted_product.id}", headers=auth_headers(SELLER_ID))
+    assert response.status_code == 204
+    assert response.content == b""
+
+    list_response = client.get(
+        "/api/v1/products",
+        params={
+            "include_deleted": "true",
+            "seller_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        },
+        headers=auth_headers(SELLER_ID),
+    )
+
+    assert list_response.status_code == 200
+    body = list_response.json()
+    assert body["total_count"] == 2
+    assert [item["id"] for item in body["items"]] == [str(visible_product.id), str(deleted_product.id)]
+    assert [item["deleted"] for item in body["items"]] == [False, True]
 
 
 def test_status_filter_works_correctly(client, test_product_factory, auth_headers):

--- a/tests/api/test_products.py
+++ b/tests/api/test_products.py
@@ -878,10 +878,12 @@ def test_list_returns_only_own_products(
     assert body["total_count"] == 2
     assert body["limit"] == 20
     assert body["offset"] == 0
-    assert [item["id"] for item in body["items"]] == [str(own_product.id), str(own_product_without_skus.id)]
+    item_ids = [item["id"] for item in body["items"]]
+    assert set(item_ids) == {str(own_product.id), str(own_product_without_skus.id)}
     assert str(other_product.id) not in [item["id"] for item in body["items"]]
 
-    first_item = body["items"][0]
+    items_by_id = {item["id"]: item for item in body["items"]}
+    first_item = items_by_id[str(own_product.id)]
     assert set(first_item) == {
         "id",
         "title",
@@ -909,7 +911,7 @@ def test_list_returns_only_own_products(
     assert "category" not in first_item
     assert "images" not in first_item
 
-    second_item = body["items"][1]
+    second_item = items_by_id[str(own_product_without_skus.id)]
     assert second_item["min_price"] is None
     assert second_item["cover_image"] == "/s3/iphone15-front.jpg"
     assert second_item["skus_count"] == 0
@@ -997,8 +999,10 @@ def test_include_deleted_true_returns_deleted_products(
     assert list_response.status_code == 200
     body = list_response.json()
     assert body["total_count"] == 2
-    assert [item["id"] for item in body["items"]] == [str(visible_product.id), str(deleted_product.id)]
-    assert [item["deleted"] for item in body["items"]] == [False, True]
+    items_by_id = {item["id"]: item for item in body["items"]}
+    assert set(items_by_id) == {str(visible_product.id), str(deleted_product.id)}
+    assert items_by_id[str(visible_product.id)]["deleted"] is False
+    assert items_by_id[str(deleted_product.id)]["deleted"] is True
 
 
 def test_status_filter_works_correctly(client, test_product_factory, auth_headers):
@@ -1052,10 +1056,10 @@ def test_search_by_title_case_insensitive(client, test_product_factory, auth_hea
     assert response.status_code == 200
     body = response.json()
     assert body["total_count"] == 2
-    assert [item["id"] for item in body["items"]] == [
+    assert {item["id"] for item in body["items"]} == {
         str(matching_product.id),
         str(another_matching_product.id),
-    ]
+    }
     assert str(non_matching_product.id) not in [item["id"] for item in body["items"]]
     assert str(other_seller_product.id) not in [item["id"] for item in body["items"]]
 


### PR DESCRIPTION
# US-B2B-11 Summary

US-B2B-11 is migrated to the final authoritative `flow/openapi.yaml` seller product list contract. For the affected seller product list endpoint, this contract matches the previously reviewed `neomarket-b2b.yaml` seller product list contract.

`GET /api/v1/products` keeps the existing mode routing: a valid `X-Service-Key` uses B2C catalog mode, an invalid service key returns `401`, and no service key requires a seller Bearer JWT for seller-list mode. Seller-list mode takes `seller_id` only from JWT claims and ignores ownership query parameters such as `seller_id`, `sellerId`, `owner_id`, and `user_id`.

Seller-list mode now returns only the authenticated seller's products, supports `limit`/`offset` bounds, exact `status` filtering, case-insensitive trimmed title `search`, and `include_deleted`. Invalid `status` returns `400 {"code":"INVALID_REQUEST","message":"status must be valid"}`. B2C catalog behavior is unchanged and still excludes deleted products.

`include_deleted=false` is the new default, including when the query parameter is omitted. It hides soft-deleted products from seller-list results. `include_deleted=true` is the explicit compatibility path for the old deleted-visible seller-list behavior.

Seller-list items now use the `ProductShortResponse`-style response shape: stringified `id`, `title`, `slug`, `status`, stringified `category_id`, `deleted`, `created_at`, `min_price`, and `cover_image`. The seller-list keeps the existing aggregate extensions `skus_count` and `total_active_quantity`. Seller-only or old nested fields such as `seller_id`, `category`, `images`, SKU `cost_price`, and `reserved_quantity` are not exposed in list items.

No migration is needed.

No US-B2B-12+ behavior is included: SKU delete behavior and SKU deleted filtering are unchanged.

# US-B2B-11 Validation

Pytest proof commands:

```powershell
python -m pytest tests/api/test_products.py -vv -k "test_list_returns_only_own_products or test_idor_query_param_seller_id_ignored or test_deleted_products_hidden_by_default or test_include_deleted_true_returns_deleted_products or test_status_filter_works_correctly or test_search_by_title_case_insensitive"
python -m pytest tests/api/test_products.py -vv
python -m pytest tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py tests/api/test_reservations.py tests/api/test_moderation_events.py tests/api/test_fulfillment.py -vv
```

Required scenario results:

- `test_list_returns_only_own_products`: passed
- `test_idor_query_param_seller_id_ignored`: passed
- `test_deleted_products_hidden_by_default`: passed
- `test_include_deleted_true_returns_deleted_products`: passed
- `test_status_filter_works_correctly`: passed
- `test_search_by_title_case_insensitive`: passed

Regression results:

- Required US-B2B-11 scenarios: 6 passed, 30 deselected
- `tests/api/test_products.py`: 36 passed
- `tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py tests/api/test_reservations.py tests/api/test_moderation_events.py tests/api/test_fulfillment.py`: 104 passed

# ADR: Seller List SKU Aggregates

Options considered:

- SQL aggregate count/sum: selected. It avoids N+1 queries, keeps list responses bounded as SKU counts grow, and fits the existing SQLAlchemy service layer with moderate maintenance cost.
- Prefetch and compute in serializer/service: simpler at first, but risks loading unnecessary SKU rows for every product as list size grows.
- Raw SQL: efficient, but higher maintenance and less consistent with the existing ORM service style.

Decision: use a grouped SQLAlchemy aggregate subquery over `SKU.product_id`, with an outer join from products so products without SKUs return `skus_count=0` and `total_active_quantity=0`.