### PR TITLE
US-B2B-12: Implement SKU deletion

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -738,17 +738,17 @@ Decision: use a grouped SQLAlchemy aggregate subquery over `SKU.product_id`, wit
 
 # US-B2B-12 Summary
 
-Implemented seller-facing `DELETE /api/v1/skus/{id}` on top of the stacked US-B2B-01 through US-B2B-11 changes. This PR depends on US-B2B-01 through US-B2B-11 until those changes are merged.
+US-B2B-12 SKU delete is migrated to the final authoritative `flow/openapi.yaml` contract. For the affected SKU delete endpoint, this contract matches the previously reviewed `neomarket-b2b.yaml` SKU delete contract.
+
+The seller-facing `DELETE /api/v1/skus/{id}` remains implemented on top of the stacked US-B2B-01 through US-B2B-11 changes. This PR depends on US-B2B-01 through US-B2B-11 until those changes are merged.
 
 The endpoint authenticates the seller from Bearer JWT claims and checks ownership through the parent product only. Missing SKUs and already-deleted SKUs return `404 {"code":"NOT_FOUND","message":"SKU not found"}`. Other sellers receive `403 NOT_OWNER`. `HARD_BLOCKED` parent products receive `403 FORBIDDEN` before active-reserve checks, including when the SKU also has reserves. SKUs with `reserved_quantity > 0` receive `409 CONFLICT` without mutation.
 
-Added a minimal `SKU.deleted` soft-delete flag and migration `0011_add_sku_deleted.py`. Successful deletes mark only `sku.deleted=true`; they do not physically delete the row and do not change `active_quantity`, `reserved_quantity`, reservation, fulfillment, invoice, or historical data. Repeated delete returns 404 to avoid duplicate side effects.
+Added a minimal `SKU.deleted` soft-delete flag and migration `0011_add_sku_deleted.py`. Successful deletes mark only `sku.deleted=true`; they do not physically delete the row and do not change `active_quantity`, `reserved_quantity`, reservation, fulfillment, invoice, or historical data. Successful SKU delete now returns `204 No Content` with an empty response body, superseding the old `200 {"ok": true}` behavior. Repeated delete returns 404 to avoid duplicate side effects.
 
 Side effects follow the required post-commit pattern. If the deleted SKU was the last non-deleted SKU on an `ON_MODERATION` product, the product returns to `CREATED` and a Moderation `DELETED` event is attempted after commit. If a `MODERATED` product SKU with positive `active_quantity` is deleted, a B2C `SKU_OUT_OF_STOCK` event is attempted after commit with a fresh UUIDv4 idempotency key. External sends are best-effort after the committed DB mutation; failures are logged and do not roll back the delete.
 
 Deleted-SKU filtering is intentionally narrow: B2C catalog product visibility and SKU serialization ignore deleted SKUs, reserve treats deleted SKUs as unavailable, and seller-list SKU aggregates count only non-deleted SKUs.
-
-OpenAPI gap: no `b2b/openapi.yaml` exists in this repository. The existing flow docs are under `flow/`, and the task scope explicitly says not to edit `flow/*`, so no OpenAPI file was changed.
 
 # US-B2B-12 Validation
 
@@ -778,9 +778,9 @@ Additional safety coverage:
 
 Suite results:
 
-- Required US-B2B-12 scenarios: 5 passed, 16 deselected
-- `tests/api/test_skus.py`: 21 passed
-- `tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py tests/api/test_reservations.py tests/api/test_moderation_events.py tests/api/test_fulfillment.py`: 79 passed
+- Required US-B2B-12 scenarios: 5 passed, 19 deselected
+- `tests/api/test_skus.py`: 24 passed
+- `tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py tests/api/test_reservations.py tests/api/test_moderation_events.py tests/api/test_fulfillment.py`: 114 passed
 
 # ADR: SKU Delete Guardrails and Soft Delete
 

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -733,3 +733,61 @@ Options considered:
 - Raw SQL: efficient, but higher maintenance and less consistent with the existing ORM service style.
 
 Decision: use a grouped SQLAlchemy aggregate subquery over `SKU.product_id`, with an outer join from products so products without SKUs return `skus_count=0` and `total_active_quantity=0`.
+
+---
+
+# US-B2B-12 Summary
+
+Implemented seller-facing `DELETE /api/v1/skus/{id}` on top of the stacked US-B2B-01 through US-B2B-11 changes. This PR depends on US-B2B-01 through US-B2B-11 until those changes are merged.
+
+The endpoint authenticates the seller from Bearer JWT claims and checks ownership through the parent product only. Missing SKUs and already-deleted SKUs return `404 {"code":"NOT_FOUND","message":"SKU not found"}`. Other sellers receive `403 NOT_OWNER`. `HARD_BLOCKED` parent products receive `403 FORBIDDEN` before active-reserve checks, including when the SKU also has reserves. SKUs with `reserved_quantity > 0` receive `409 CONFLICT` without mutation.
+
+Added a minimal `SKU.deleted` soft-delete flag and migration `0011_add_sku_deleted.py`. Successful deletes mark only `sku.deleted=true`; they do not physically delete the row and do not change `active_quantity`, `reserved_quantity`, reservation, fulfillment, invoice, or historical data. Repeated delete returns 404 to avoid duplicate side effects.
+
+Side effects follow the required post-commit pattern. If the deleted SKU was the last non-deleted SKU on an `ON_MODERATION` product, the product returns to `CREATED` and a Moderation `DELETED` event is attempted after commit. If a `MODERATED` product SKU with positive `active_quantity` is deleted, a B2C `SKU_OUT_OF_STOCK` event is attempted after commit with a fresh UUIDv4 idempotency key. External sends are best-effort after the committed DB mutation; failures are logged and do not roll back the delete.
+
+Deleted-SKU filtering is intentionally narrow: B2C catalog product visibility and SKU serialization ignore deleted SKUs, reserve treats deleted SKUs as unavailable, and seller-list SKU aggregates count only non-deleted SKUs.
+
+OpenAPI gap: no `b2b/openapi.yaml` exists in this repository. The existing flow docs are under `flow/`, and the task scope explicitly says not to edit `flow/*`, so no OpenAPI file was changed.
+
+# US-B2B-12 Validation
+
+Pytest proof commands:
+
+```powershell
+python -m pytest tests/api/test_skus.py -vv -k "delete_sku_succeeds or delete_sku_with_active_reserves_returns_409 or last_sku_on_moderation_transitions_product_to_created or delete_sku_hard_blocked_product_returns_403 or sku_out_of_stock_event_on_moderated_product"
+python -m pytest tests/api/test_skus.py -vv
+python -m pytest tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py tests/api/test_reservations.py tests/api/test_moderation_events.py tests/api/test_fulfillment.py -vv
+```
+
+Required scenario results:
+
+- `test_delete_sku_succeeds`: passed
+- `test_delete_sku_with_active_reserves_returns_409`: passed
+- `test_last_sku_on_moderation_transitions_product_to_created`: passed
+- `test_delete_sku_hard_blocked_product_returns_403`: passed
+- `test_sku_out_of_stock_event_on_moderated_product`: passed
+
+Additional safety coverage:
+
+- already-deleted SKU returns 404 and sends no events
+- other seller cannot delete SKU
+- `active_quantity == 0` on a moderated product does not emit `SKU_OUT_OF_STOCK`
+- deleted SKUs are filtered from B2C catalog, reserve, and seller-list aggregates
+- adding a new SKU after deleting the last non-deleted SKU starts moderation again
+
+Suite results:
+
+- Required US-B2B-12 scenarios: 5 passed, 16 deselected
+- `tests/api/test_skus.py`: 21 passed
+- `tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py tests/api/test_reservations.py tests/api/test_moderation_events.py tests/api/test_fulfillment.py`: 79 passed
+
+# ADR: SKU Delete Guardrails and Soft Delete
+
+Options considered:
+
+- Separate early guardrail checks: selected. It keeps ownership, `HARD_BLOCKED`, and active-reserve precedence explicit and lowest risk, especially because `HARD_BLOCKED` must win over reserve conflicts.
+- Single `validate_deletion` helper: compact, but it makes the required order easier to obscure and increases the chance of future changes returning the wrong error.
+- Serializer/schema checks: wrong layer for DB-backed ownership, status, deleted-state, and reserve rules.
+
+Decision: keep delete validation in the SKU service as ordered early checks, then soft-delete and commit before best-effort event sends.

--- a/migrations/versions/0011_add_sku_deleted.py
+++ b/migrations/versions/0011_add_sku_deleted.py
@@ -1,0 +1,24 @@
+"""Add SKU deleted flag."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0011_add_sku_deleted"
+down_revision = "0010_add_fulfilled_orders"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "skus",
+        sa.Column("deleted", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    op.alter_column("skus", "deleted", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column("skus", "deleted")

--- a/src/api/routes/skus.py
+++ b/src/api/routes/skus.py
@@ -11,9 +11,11 @@ from src.schemas.sku import SKUCreate, SKURead, SKUUpdate
 from src.services.errors import NotFoundError
 from src.services.sku_service import (
     ModerationUnavailableError,
+    SKUConflictError,
     SKUForbiddenError,
     SKUOwnerError,
     create_sku,
+    delete_sku,
     update_sku,
 )
 
@@ -114,6 +116,29 @@ async def create_sku_endpoint(
         return _error(403, "FORBIDDEN", str(exc))
     except ModerationUnavailableError:
         return _error(502, "MODERATION_UNAVAILABLE", "Moderation service unavailable")
+
+
+@router.delete("/{id}", response_model=None, status_code=status.HTTP_200_OK)
+def delete_sku_endpoint(
+    id: uuid.UUID,
+    current_seller: CurrentSeller | JSONResponse = Depends(get_current_seller),
+    db: Session = Depends(get_db),
+) -> dict[str, bool] | JSONResponse:
+    if isinstance(current_seller, JSONResponse):
+        return current_seller
+
+    try:
+        delete_sku(db, id, current_seller.seller_id)
+    except NotFoundError:
+        return _error(404, "NOT_FOUND", "SKU not found")
+    except SKUOwnerError as exc:
+        return _error(403, "NOT_OWNER", str(exc))
+    except SKUForbiddenError as exc:
+        return _error(403, "FORBIDDEN", str(exc))
+    except SKUConflictError as exc:
+        return _error(409, "CONFLICT", str(exc))
+
+    return {"ok": True}
 
 
 @router.put("/{id}", response_model=SKURead, status_code=status.HTTP_200_OK)

--- a/src/api/routes/skus.py
+++ b/src/api/routes/skus.py
@@ -1,6 +1,6 @@
 import uuid
 
-from fastapi import APIRouter, Depends, Request, status
+from fastapi import APIRouter, Depends, Request, Response, status
 from fastapi.responses import JSONResponse
 from pydantic import ValidationError as PydanticValidationError
 from sqlalchemy.orm import Session
@@ -118,17 +118,17 @@ async def create_sku_endpoint(
         return _error(502, "MODERATION_UNAVAILABLE", "Moderation service unavailable")
 
 
-@router.delete("/{id}", response_model=None, status_code=status.HTTP_200_OK)
+@router.delete("/{sku_id}", response_model=None, status_code=status.HTTP_204_NO_CONTENT)
 def delete_sku_endpoint(
-    id: uuid.UUID,
+    sku_id: uuid.UUID,
     current_seller: CurrentSeller | JSONResponse = Depends(get_current_seller),
     db: Session = Depends(get_db),
-) -> dict[str, bool] | JSONResponse:
+) -> Response | JSONResponse:
     if isinstance(current_seller, JSONResponse):
         return current_seller
 
     try:
-        delete_sku(db, id, current_seller.seller_id)
+        delete_sku(db, sku_id, current_seller.seller_id)
     except NotFoundError:
         return _error(404, "NOT_FOUND", "SKU not found")
     except SKUOwnerError as exc:
@@ -138,7 +138,7 @@ def delete_sku_endpoint(
     except SKUConflictError as exc:
         return _error(409, "CONFLICT", str(exc))
 
-    return {"ok": True}
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.put("/{id}", response_model=SKURead, status_code=status.HTTP_200_OK)

--- a/src/models/sku.py
+++ b/src/models/sku.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 import uuid
 
-from sqlalchemy import DateTime, ForeignKey, Integer, String, func
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, false, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.db.types import GUID
@@ -21,6 +21,7 @@ class SKU(Base):
     image: Mapped[str] = mapped_column(String(1024), nullable=False, default="")
     active_quantity: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     reserved_quantity: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    deleted: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default=false())
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         server_default=func.now(),

--- a/src/services/product_service.py
+++ b/src/services/product_service.py
@@ -3,7 +3,7 @@ import uuid
 from collections.abc import Sequence
 from dataclasses import dataclass
 
-from sqlalchemy import func, select
+from sqlalchemy import and_, func, select
 from sqlalchemy.orm import Session, selectinload
 
 from src.models import Category, Product, ProductCharacteristic, ProductImage, ProductStatus, SKU
@@ -131,6 +131,7 @@ def list_seller_products(
             func.coalesce(func.sum(SKU.active_quantity), 0).label("total_active_quantity"),
             func.min(SKU.price).label("min_price"),
         )
+        .where(SKU.deleted.is_(False))
         .group_by(SKU.product_id)
         .subquery()
     )
@@ -174,7 +175,7 @@ def list_catalog_products(
     filters = [
         Product.status == ProductStatus.MODERATED,
         Product.deleted.is_(False),
-        Product.skus.any(SKU.active_quantity > 0),
+        Product.skus.any(and_(SKU.active_quantity > 0, SKU.deleted.is_(False))),
     ]
     if product_ids is not None:
         filters.append(Product.id.in_(product_ids))

--- a/src/services/reservation_service.py
+++ b/src/services/reservation_service.py
@@ -102,7 +102,7 @@ def _lock_skus(db: Session, sku_ids: list[uuid.UUID]) -> dict[uuid.UUID, SKU]:
 def _is_visible_catalog_sku(sku: SKU | None) -> bool:
     if sku is None or sku.product is None:
         return False
-    return sku.product.status == ProductStatus.MODERATED and sku.product.deleted is False
+    return sku.product.status == ProductStatus.MODERATED and sku.product.deleted is False and sku.deleted is False
 
 
 def _reserve_conflicts(items: list[dict[str, Any]], sku_map: dict[uuid.UUID, SKU]) -> list[dict[str, Any]]:

--- a/src/services/sku_service.py
+++ b/src/services/sku_service.py
@@ -1,3 +1,4 @@
+import logging
 import uuid
 
 from sqlalchemy import select
@@ -5,8 +6,15 @@ from sqlalchemy.orm import Session, selectinload
 
 from src.models import Product, ProductStatus, SKU, SKUCharacteristic
 from src.schemas.sku import SKUCreate, SKUUpdate
-from src.services.moderation_service import send_product_created_event, send_product_edited_event
+from src.services.b2c_service import send_sku_out_of_stock_event
 from src.services.errors import NotFoundError
+from src.services.moderation_service import (
+    send_product_created_event,
+    send_product_deleted_event,
+    send_product_edited_event,
+)
+
+logger = logging.getLogger(__name__)
 
 
 class SKUForbiddenError(Exception):
@@ -14,6 +22,10 @@ class SKUForbiddenError(Exception):
 
 
 class SKUOwnerError(Exception):
+    pass
+
+
+class SKUConflictError(Exception):
     pass
 
 
@@ -32,8 +44,22 @@ def _get_product_or_raise(db: Session, product_id: uuid.UUID) -> Product:
     return product
 
 
+def _sku_delete_query():
+    return select(SKU).options(
+        selectinload(SKU.characteristics),
+        selectinload(SKU.product).selectinload(Product.skus),
+    )
+
+
 def _get_sku_or_raise(db: Session, sku_id: uuid.UUID) -> SKU:
     sku = db.scalars(_sku_query().where(SKU.id == sku_id)).first()
+    if sku is None:
+        raise NotFoundError(f"SKU with id={sku_id} not found")
+    return sku
+
+
+def _get_non_deleted_sku_or_raise(db: Session, sku_id: uuid.UUID) -> SKU:
+    sku = db.scalars(_sku_delete_query().where(SKU.id == sku_id, SKU.deleted.is_(False))).first()
     if sku is None:
         raise NotFoundError(f"SKU with id={sku_id} not found")
     return sku
@@ -58,7 +84,9 @@ def create_sku(db: Session, payload: SKUCreate, seller_id: uuid.UUID) -> SKU:
     if product.status == ProductStatus.HARD_BLOCKED:
         raise SKUForbiddenError("Cannot add SKU to hard-blocked product")
 
-    should_send_moderation_event = product.status == ProductStatus.CREATED and len(product.skus) == 0
+    should_send_moderation_event = product.status == ProductStatus.CREATED and all(
+        product_sku.deleted for product_sku in product.skus
+    )
     image = payload.images[0].url if payload.images else payload.image or ""
 
     sku = SKU(
@@ -137,4 +165,45 @@ def update_sku(db: Session, sku_id: uuid.UUID, payload: SKUUpdate, seller_id: uu
 
     db.commit()
     return _get_sku_or_raise(db, sku.id)
+
+
+def delete_sku(db: Session, sku_id: uuid.UUID, seller_id: uuid.UUID) -> None:
+    sku = _get_non_deleted_sku_or_raise(db, sku_id)
+    product = sku.product
+
+    if product.seller_id != seller_id:
+        raise SKUOwnerError("Product does not belong to the authenticated seller")
+    if product.status == ProductStatus.HARD_BLOCKED:
+        raise SKUForbiddenError("Cannot delete SKU of hard-blocked product")
+    if sku.reserved_quantity > 0:
+        raise SKUConflictError("Cannot delete SKU with active reserves")
+
+    should_send_b2c_out_of_stock = product.status == ProductStatus.MODERATED and sku.active_quantity > 0
+
+    sku.deleted = True
+    remaining_sku_count = sum(1 for product_sku in product.skus if not product_sku.deleted)
+    should_send_moderation_deleted = (
+        remaining_sku_count == 0
+        and product.status == ProductStatus.ON_MODERATION
+    )
+    if should_send_moderation_deleted:
+        product.status = ProductStatus.CREATED
+
+    db.commit()
+
+    if should_send_moderation_deleted:
+        try:
+            send_product_deleted_event(product_id=str(product.id), seller_id=str(seller_id))
+        except Exception:
+            logger.exception("Failed to send product DELETED event to Moderation after SKU delete")
+
+    if should_send_b2c_out_of_stock:
+        try:
+            send_sku_out_of_stock_event(
+                idempotency_key=str(uuid.uuid4()),
+                product_id=str(product.id),
+                sku_id=str(sku.id),
+            )
+        except Exception:
+            logger.exception("Failed to send SKU_OUT_OF_STOCK event to B2C after SKU delete")
 

--- a/tests/api/test_skus.py
+++ b/tests/api/test_skus.py
@@ -84,11 +84,18 @@ def sku_payload(product_id: UUID, **overrides) -> dict:
     return payload
 
 
-def sku_count(db_session: Session, product_id: int) -> int:
+def sku_count(db_session: Session, product_id: UUID) -> int:
     return db_session.scalar(select(func.count(SKU.id)).where(SKU.product_id == product_id))
 
 
-def create_existing_sku(db_session: Session, product: Product, *, reserved_quantity: int = 0) -> SKU:
+def create_existing_sku(
+    db_session: Session,
+    product: Product,
+    *,
+    active_quantity: int = 0,
+    reserved_quantity: int = 0,
+    deleted: bool = False,
+) -> SKU:
     sku = SKU(
         product_id=product.id,
         name="128GB Black",
@@ -96,8 +103,9 @@ def create_existing_sku(db_session: Session, product: Product, *, reserved_quant
         cost_price=7000000,
         discount=0,
         image="/s3/iphone15-black-128.jpg",
-        active_quantity=0,
+        active_quantity=active_quantity,
         reserved_quantity=reserved_quantity,
+        deleted=deleted,
     )
     db_session.add(sku)
     db_session.commit()
@@ -112,6 +120,10 @@ def assert_sku_image(body: dict, url: str) -> None:
     assert image["id"] != body["id"]
     assert image["url"] == url
     assert image["ordering"] == 0
+
+
+def assert_uuid(value: str) -> None:
+    UUID(value)
 
 
 def test_first_sku_transitions_product_to_on_moderation(
@@ -402,7 +414,7 @@ def test_patch_sku_alias_updates_sku(
             "name": "128GB Natural Titanium",
             "article": "IPHONE15-NATURAL-128",
             "reserved_quantity": 999,
-            "product_id": 999999,
+            "product_id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
             "seller_id": "body-seller",
         },
         headers=auth_headers(SELLER_ID),
@@ -525,3 +537,280 @@ def test_patch_others_product_returns_403(
     assert persisted_product.status == ProductStatus.MODERATED
     assert persisted_sku.name == "128GB Black"
     assert moderation_requests == []
+
+
+def test_delete_sku_succeeds(
+    client,
+    db_session: Session,
+    product_factory,
+    auth_headers,
+    moderation_requests,
+):
+    product = product_factory(status=ProductStatus.CREATED)
+    sku = create_existing_sku(db_session, product, active_quantity=12, reserved_quantity=0)
+
+    response = client.delete(f"/api/v1/skus/{sku.id}", headers=auth_headers(SELLER_ID))
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+    db_session.expire_all()
+    persisted_sku = db_session.get(SKU, sku.id)
+    persisted_product = db_session.get(Product, product.id)
+    assert persisted_sku.deleted is True
+    assert persisted_sku.active_quantity == 12
+    assert persisted_sku.reserved_quantity == 0
+    assert persisted_product.status == ProductStatus.CREATED
+    assert moderation_requests == []
+
+
+def test_delete_sku_with_active_reserves_returns_409(
+    client,
+    db_session: Session,
+    product_factory,
+    auth_headers,
+    moderation_requests,
+):
+    product = product_factory(status=ProductStatus.MODERATED)
+    sku = create_existing_sku(db_session, product, active_quantity=3, reserved_quantity=2)
+
+    response = client.delete(f"/api/v1/skus/{sku.id}", headers=auth_headers(SELLER_ID))
+
+    assert response.status_code == 409
+    assert response.json() == {
+        "code": "CONFLICT",
+        "message": "Cannot delete SKU with active reserves",
+    }
+
+    db_session.expire_all()
+    persisted_sku = db_session.get(SKU, sku.id)
+    persisted_product = db_session.get(Product, product.id)
+    assert persisted_sku.deleted is False
+    assert persisted_sku.active_quantity == 3
+    assert persisted_sku.reserved_quantity == 2
+    assert persisted_product.status == ProductStatus.MODERATED
+    assert moderation_requests == []
+
+
+def test_last_sku_on_moderation_transitions_product_to_created(
+    client,
+    db_session: Session,
+    product_factory,
+    auth_headers,
+    moderation_requests,
+):
+    product = product_factory(status=ProductStatus.ON_MODERATION)
+    sku = create_existing_sku(db_session, product, active_quantity=0, reserved_quantity=0)
+
+    response = client.delete(f"/api/v1/skus/{sku.id}", headers=auth_headers(SELLER_ID))
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+    db_session.expire_all()
+    persisted_sku = db_session.get(SKU, sku.id)
+    persisted_product = db_session.get(Product, product.id)
+    assert persisted_sku.deleted is True
+    assert persisted_product.status == ProductStatus.CREATED
+
+    assert len(moderation_requests) == 1
+    request = moderation_requests[0]
+    event = request["json"]
+    assert request["url"] == f"{settings.moderation_url}/api/v1/events/product"
+    assert request["headers"]["X-Service-Key"] == settings.b2b_to_mod_key
+    assert event["product_id"] == str(product.id)
+    assert event["seller_id"] == SELLER_ID
+    assert event["event"] == "DELETED"
+    assert event["date"]
+    assert_uuid(event["idempotency_key"])
+
+
+def test_new_sku_after_last_deleted_sku_starts_moderation(
+    client,
+    db_session: Session,
+    product_factory,
+    auth_headers,
+    moderation_requests,
+):
+    product = product_factory(status=ProductStatus.ON_MODERATION)
+    sku = create_existing_sku(db_session, product, active_quantity=0, reserved_quantity=0)
+
+    delete_response = client.delete(f"/api/v1/skus/{sku.id}", headers=auth_headers(SELLER_ID))
+    create_response = client.post(
+        "/api/v1/skus",
+        json=sku_payload(product.id, name="256GB Natural Titanium"),
+        headers=auth_headers(SELLER_ID),
+    )
+
+    assert delete_response.status_code == 200
+    assert create_response.status_code == 201
+    db_session.expire_all()
+    persisted_product = db_session.get(Product, product.id)
+    assert persisted_product.status == ProductStatus.ON_MODERATION
+    assert [request["json"]["event"] for request in moderation_requests] == ["DELETED", "CREATED"]
+
+
+def test_delete_sku_hard_blocked_product_returns_403(
+    client,
+    db_session: Session,
+    product_factory,
+    auth_headers,
+    moderation_requests,
+):
+    product = product_factory(status=ProductStatus.HARD_BLOCKED)
+    sku = create_existing_sku(db_session, product, active_quantity=4, reserved_quantity=2)
+
+    response = client.delete(f"/api/v1/skus/{sku.id}", headers=auth_headers(SELLER_ID))
+
+    assert response.status_code == 403
+    assert response.json() == {
+        "code": "FORBIDDEN",
+        "message": "Cannot delete SKU of hard-blocked product",
+    }
+
+    db_session.expire_all()
+    persisted_sku = db_session.get(SKU, sku.id)
+    persisted_product = db_session.get(Product, product.id)
+    assert persisted_sku.deleted is False
+    assert persisted_sku.reserved_quantity == 2
+    assert persisted_product.status == ProductStatus.HARD_BLOCKED
+    assert moderation_requests == []
+
+
+def test_sku_out_of_stock_event_on_moderated_product(
+    client,
+    db_session: Session,
+    product_factory,
+    auth_headers,
+    moderation_requests,
+):
+    product = product_factory(status=ProductStatus.MODERATED)
+    sku = create_existing_sku(db_session, product, active_quantity=5, reserved_quantity=0)
+
+    response = client.delete(f"/api/v1/skus/{sku.id}", headers=auth_headers(SELLER_ID))
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+    db_session.expire_all()
+    persisted_sku = db_session.get(SKU, sku.id)
+    persisted_product = db_session.get(Product, product.id)
+    assert persisted_sku.deleted is True
+    assert persisted_sku.active_quantity == 5
+    assert persisted_product.status == ProductStatus.MODERATED
+
+    assert len(moderation_requests) == 1
+    request = moderation_requests[0]
+    event = request["json"]
+    assert request["url"] == f"{settings.b2c_url}/api/v1/events/product"
+    assert request["headers"]["X-Service-Key"] == settings.b2b_to_b2c_key
+    assert event["event"] == "SKU_OUT_OF_STOCK"
+    assert event["product_id"] == str(product.id)
+    assert event["sku_id"] == str(sku.id)
+    assert event["date"]
+    assert_uuid(event["idempotency_key"])
+
+
+def test_already_deleted_sku_returns_404_and_sends_no_events(
+    client,
+    db_session: Session,
+    product_factory,
+    auth_headers,
+    moderation_requests,
+):
+    product = product_factory(status=ProductStatus.MODERATED)
+    sku = create_existing_sku(db_session, product, active_quantity=5, deleted=True)
+
+    response = client.delete(f"/api/v1/skus/{sku.id}", headers=auth_headers(SELLER_ID))
+
+    assert response.status_code == 404
+    assert response.json() == {"code": "NOT_FOUND", "message": "SKU not found"}
+    db_session.expire_all()
+    assert db_session.get(SKU, sku.id).deleted is True
+    assert moderation_requests == []
+
+
+def test_delete_others_sku_returns_403(
+    client,
+    db_session: Session,
+    product_factory,
+    auth_headers,
+    moderation_requests,
+):
+    other_seller_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    product = product_factory(seller_id=SELLER_ID, status=ProductStatus.MODERATED)
+    sku = create_existing_sku(db_session, product, active_quantity=5)
+
+    response = client.delete(f"/api/v1/skus/{sku.id}", headers=auth_headers(other_seller_id))
+
+    assert response.status_code == 403
+    assert response.json() == {
+        "code": "NOT_OWNER",
+        "message": "Product does not belong to the authenticated seller",
+    }
+    db_session.expire_all()
+    assert db_session.get(SKU, sku.id).deleted is False
+    assert moderation_requests == []
+
+
+def test_delete_zero_stock_moderated_sku_does_not_emit_out_of_stock(
+    client,
+    db_session: Session,
+    product_factory,
+    auth_headers,
+    moderation_requests,
+):
+    product = product_factory(status=ProductStatus.MODERATED)
+    sku = create_existing_sku(db_session, product, active_quantity=0, reserved_quantity=0)
+
+    response = client.delete(f"/api/v1/skus/{sku.id}", headers=auth_headers(SELLER_ID))
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    db_session.expire_all()
+    assert db_session.get(SKU, sku.id).deleted is True
+    assert moderation_requests == []
+
+
+def test_deleted_sku_filtered_from_catalog_reserve_and_seller_aggregates(
+    client,
+    db_session: Session,
+    product_factory,
+    auth_headers,
+    moderation_requests,
+):
+    product = product_factory(status=ProductStatus.MODERATED)
+    sku = create_existing_sku(db_session, product, active_quantity=6, reserved_quantity=0)
+
+    delete_response = client.delete(f"/api/v1/skus/{sku.id}", headers=auth_headers(SELLER_ID))
+    assert delete_response.status_code == 200
+
+    catalog_response = client.get(
+        "/api/v1/products",
+        headers={"X-Service-Key": settings.b2c_to_b2b_key},
+    )
+    reserve_response = client.post(
+        "/api/v1/reserve",
+        json={"idempotency_key": "deleted-sku-reserve", "items": [{"sku_id": str(sku.id), "quantity": 1}]},
+        headers={"X-Service-Key": settings.b2c_to_b2b_key},
+    )
+    seller_list_response = client.get("/api/v1/products", headers=auth_headers(SELLER_ID))
+
+    assert catalog_response.status_code == 200
+    assert catalog_response.json()["items"] == []
+    assert reserve_response.status_code == 409
+    assert reserve_response.json() == {
+        "reserved": False,
+        "failed_items": [
+            {
+                "sku_id": str(sku.id),
+                "requested": 1,
+                "available": 0,
+                "reason": "OUT_OF_STOCK",
+            }
+        ],
+    }
+    assert seller_list_response.status_code == 200
+    seller_item = seller_list_response.json()["items"][0]
+    assert seller_item["skus_count"] == 0
+    assert seller_item["total_active_quantity"] == 0

--- a/tests/api/test_skus.py
+++ b/tests/api/test_skus.py
@@ -551,8 +551,8 @@ def test_delete_sku_succeeds(
 
     response = client.delete(f"/api/v1/skus/{sku.id}", headers=auth_headers(SELLER_ID))
 
-    assert response.status_code == 200
-    assert response.json() == {"ok": True}
+    assert response.status_code == 204
+    assert response.content == b""
 
     db_session.expire_all()
     persisted_sku = db_session.get(SKU, sku.id)
@@ -604,8 +604,8 @@ def test_last_sku_on_moderation_transitions_product_to_created(
 
     response = client.delete(f"/api/v1/skus/{sku.id}", headers=auth_headers(SELLER_ID))
 
-    assert response.status_code == 200
-    assert response.json() == {"ok": True}
+    assert response.status_code == 204
+    assert response.content == b""
 
     db_session.expire_all()
     persisted_sku = db_session.get(SKU, sku.id)
@@ -642,7 +642,8 @@ def test_new_sku_after_last_deleted_sku_starts_moderation(
         headers=auth_headers(SELLER_ID),
     )
 
-    assert delete_response.status_code == 200
+    assert delete_response.status_code == 204
+    assert delete_response.content == b""
     assert create_response.status_code == 201
     db_session.expire_all()
     persisted_product = db_session.get(Product, product.id)
@@ -689,8 +690,8 @@ def test_sku_out_of_stock_event_on_moderated_product(
 
     response = client.delete(f"/api/v1/skus/{sku.id}", headers=auth_headers(SELLER_ID))
 
-    assert response.status_code == 200
-    assert response.json() == {"ok": True}
+    assert response.status_code == 204
+    assert response.content == b""
 
     db_session.expire_all()
     persisted_sku = db_session.get(SKU, sku.id)
@@ -765,8 +766,8 @@ def test_delete_zero_stock_moderated_sku_does_not_emit_out_of_stock(
 
     response = client.delete(f"/api/v1/skus/{sku.id}", headers=auth_headers(SELLER_ID))
 
-    assert response.status_code == 200
-    assert response.json() == {"ok": True}
+    assert response.status_code == 204
+    assert response.content == b""
     db_session.expire_all()
     assert db_session.get(SKU, sku.id).deleted is True
     assert moderation_requests == []
@@ -783,7 +784,8 @@ def test_deleted_sku_filtered_from_catalog_reserve_and_seller_aggregates(
     sku = create_existing_sku(db_session, product, active_quantity=6, reserved_quantity=0)
 
     delete_response = client.delete(f"/api/v1/skus/{sku.id}", headers=auth_headers(SELLER_ID))
-    assert delete_response.status_code == 200
+    assert delete_response.status_code == 204
+    assert delete_response.content == b""
 
     catalog_response = client.get(
         "/api/v1/products",


### PR DESCRIPTION
# US-B2B-12 Summary

US-B2B-12 SKU delete is migrated to the final authoritative `flow/openapi.yaml` contract. For the affected SKU delete endpoint, this contract matches the previously reviewed `neomarket-b2b.yaml` SKU delete contract.

The seller-facing `DELETE /api/v1/skus/{id}` remains implemented on top of the stacked US-B2B-01 through US-B2B-11 changes. This PR depends on US-B2B-01 through US-B2B-11 until those changes are merged.

The endpoint authenticates the seller from Bearer JWT claims and checks ownership through the parent product only. Missing SKUs and already-deleted SKUs return `404 {"code":"NOT_FOUND","message":"SKU not found"}`. Other sellers receive `403 NOT_OWNER`. `HARD_BLOCKED` parent products receive `403 FORBIDDEN` before active-reserve checks, including when the SKU also has reserves. SKUs with `reserved_quantity > 0` receive `409 CONFLICT` without mutation.

Added a minimal `SKU.deleted` soft-delete flag and migration `0011_add_sku_deleted.py`. Successful deletes mark only `sku.deleted=true`; they do not physically delete the row and do not change `active_quantity`, `reserved_quantity`, reservation, fulfillment, invoice, or historical data. Successful SKU delete now returns `204 No Content` with an empty response body, superseding the old `200 {"ok": true}` behavior. Repeated delete returns 404 to avoid duplicate side effects.

Side effects follow the required post-commit pattern. If the deleted SKU was the last non-deleted SKU on an `ON_MODERATION` product, the product returns to `CREATED` and a Moderation `DELETED` event is attempted after commit. If a `MODERATED` product SKU with positive `active_quantity` is deleted, a B2C `SKU_OUT_OF_STOCK` event is attempted after commit with a fresh UUIDv4 idempotency key. External sends are best-effort after the committed DB mutation; failures are logged and do not roll back the delete.

Deleted-SKU filtering is intentionally narrow: B2C catalog product visibility and SKU serialization ignore deleted SKUs, reserve treats deleted SKUs as unavailable, and seller-list SKU aggregates count only non-deleted SKUs.

# US-B2B-12 Validation

Pytest proof commands:

```powershell
python -m pytest tests/api/test_skus.py -vv -k "delete_sku_succeeds or delete_sku_with_active_reserves_returns_409 or last_sku_on_moderation_transitions_product_to_created or delete_sku_hard_blocked_product_returns_403 or sku_out_of_stock_event_on_moderated_product"
python -m pytest tests/api/test_skus.py -vv
python -m pytest tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py tests/api/test_reservations.py tests/api/test_moderation_events.py tests/api/test_fulfillment.py -vv
```

Required scenario results:

- `test_delete_sku_succeeds`: passed
- `test_delete_sku_with_active_reserves_returns_409`: passed
- `test_last_sku_on_moderation_transitions_product_to_created`: passed
- `test_delete_sku_hard_blocked_product_returns_403`: passed
- `test_sku_out_of_stock_event_on_moderated_product`: passed

Additional safety coverage:

- already-deleted SKU returns 404 and sends no events
- other seller cannot delete SKU
- `active_quantity == 0` on a moderated product does not emit `SKU_OUT_OF_STOCK`
- deleted SKUs are filtered from B2C catalog, reserve, and seller-list aggregates
- adding a new SKU after deleting the last non-deleted SKU starts moderation again

Suite results:

- Required US-B2B-12 scenarios: 5 passed, 19 deselected
- `tests/api/test_skus.py`: 24 passed
- `tests/api/test_products.py tests/api/test_skus.py tests/api/test_invoices.py tests/api/test_reservations.py tests/api/test_moderation_events.py tests/api/test_fulfillment.py`: 114 passed

# ADR: SKU Delete Guardrails and Soft Delete

Options considered:

- Separate early guardrail checks: selected. It keeps ownership, `HARD_BLOCKED`, and active-reserve precedence explicit and lowest risk, especially because `HARD_BLOCKED` must win over reserve conflicts.
- Single `validate_deletion` helper: compact, but it makes the required order easier to obscure and increases the chance of future changes returning the wrong error.
- Serializer/schema checks: wrong layer for DB-backed ownership, status, deleted-state, and reserve rules.

Decision: keep delete validation in the SKU service as ordered early checks, then soft-delete and commit before best-effort event sends.